### PR TITLE
New: Support `unknown` keyword

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -150,6 +150,7 @@ module.exports = {
     TSTypeReference: "TSTypeReference",
     TSUnionType: "TSUnionType",
     TSUndefinedKeyword: "TSUndefinedKeyword",
+    TSUnknownKeyword: "TSUnknownKeyword",
     TSVoidKeyword: "TSVoidKeyword",
     UnaryExpression: "UnaryExpression",
     UpdateExpression: "UpdateExpression",

--- a/lib/node-utils.js
+++ b/lib/node-utils.js
@@ -326,6 +326,7 @@ function isTypeKeyword(kind) {
         case SyntaxKind.ObjectKeyword:
         case SyntaxKind.StringKeyword:
         case SyntaxKind.SymbolKeyword:
+        case SyntaxKind.UnknownKeyword:
         case SyntaxKind.VoidKeyword:
             return true;
         default:

--- a/tests/ast-alignment/fixtures-to-test.js
+++ b/tests/ast-alignment/fixtures-to-test.js
@@ -382,6 +382,11 @@ let fixturePatternConfigsToTest = [
              */
             "declare-function",
             /**
+             * Babylon: TSTypeReference + identifier
+             * tsep: TSUnknownKeyword
+             */
+            "unknown-type-annotation",
+            /**
              * Other major AST differences (e.g. fundamentally different node types)
              */
             "class-with-mixin",

--- a/tests/fixtures/typescript/basics/unknown-type-annotation.src.ts
+++ b/tests/fixtures/typescript/basics/unknown-type-annotation.src.ts
@@ -1,0 +1,1 @@
+let foo: unknown;

--- a/tests/lib/__snapshots__/typescript.js.snap
+++ b/tests/lib/__snapshots__/typescript.js.snap
@@ -44884,6 +44884,211 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/unknown-type-annotation.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 1,
+              },
+            },
+            "name": "foo",
+            "range": Array [
+              4,
+              16,
+            ],
+            "type": "Identifier",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 7,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                7,
+                16,
+              ],
+              "type": "TSTypeAnnotation",
+              "typeAnnotation": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 9,
+                    "line": 1,
+                  },
+                },
+                "range": Array [
+                  9,
+                  16,
+                ],
+                "type": "TSUnknownKeyword",
+              },
+            },
+          },
+          "init": null,
+          "loc": Object {
+            "end": Object {
+              "column": 16,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            4,
+            16,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "let",
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        17,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    18,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        3,
+      ],
+      "type": "Keyword",
+      "value": "let",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        4,
+        7,
+      ],
+      "type": "Identifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        16,
+      ],
+      "type": "Identifier",
+      "value": "unknown",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/var-with-definite-assignment.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
This PR adds support for `unknown` keyword which is since TypeScript 3.0.

Note that the test will be failed when comparing to Babylon's AST, because Babylon doesn't support `unknown` as a keyword so far. Here is the related PR: https://github.com/babel/babel/pull/8755