### PR TITLE
Chore: Force LF for tsx files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 *.js eol=lf
 *.ts eol=lf
+*.tsx eol=lf
 *.yml eol=lf


### PR DESCRIPTION
Fixes #10.

When checking out the repo on a windows machine, the TSX test files can be currently checked out as CRLF, causing the corresponding tests to fail.