### PR TITLE
feat: document API and standardize config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">TypeScript ESTree</h1>
 
-<p align="center">A parser that converts TypeScript source code into an ESTree-compatible form: https://github.com/estree/estree</p>
+<p align="center">A parser that converts TypeScript source code into an <a href="https://github.com/estree/estree">ESTree</a>-compatible form</p>
 
 <p align="center">
     <a href="https://travis-ci.org/JamesHenry/typescript-estree"><img src="https://img.shields.io/travis/JamesHenry/typescript-estree.svg?style=flat-square" alt="Travis"/></a>
@@ -13,15 +13,97 @@
 
 <br>
 
-## Usage
+## About
 
-This parser is somewhat generic and robust, it could be used to power any use-case which requires taking TypeScript source code and producing an ESTree-compatiable AST.
+This parser is somewhat generic and robust, and could be used to power any use-case which requires taking TypeScript source code and producing an ESTree-compatiable AST.
 
 In fact, it is already used within these hyper-popular open-source projects to power their TypeScript support:
 
 - [ESLint](https://eslint.org), the pluggable linting utility for JavaScript and JSX
   - See [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser) for more details
 - [Prettier](https://prettier.io), an opinionated code formatter
+
+## Installation
+
+```
+npm install --save typescript-estree
+```
+
+## API
+
+### parse(code, options)
+
+Parses the given string of code with the options provided and returns an ESTree-compatible AST. The options object has the following properties:
+
+```javascript
+{
+    // attach range information to each node
+    range: false,
+
+    // attach line/column location information to each node
+    loc: false,
+
+    // create a top-level tokens array containing all tokens
+    tokens: false,
+
+    // create a top-level comments array containing all comments
+    comment: false,
+
+    // enable parsing JSX. For more details, see https://www.typescriptlang.org/docs/handbook/jsx.html
+    jsx: false,
+
+    /*
+     * The JSX AST changed the node type for string literals
+     * inside a JSX Element from `Literal` to `JSXText`.
+     * When value is `true`, these nodes will be parsed as type `JSXText`.
+     * When value is `false`, these nodes will be parsed as type `Literal`.
+     */
+    useJSXTextNode: false,
+
+    // Cause the parser to error if it encounters an unknown AST node type (useful for testing)
+    errorOnUnknownASTType: false,
+
+    /*
+     * Allows overriding of function used for logging.
+     * When value is `false`, no logging will occur.
+     * When value is not provided, `console.log()` will be used.
+     */
+    loggerFn: undefined
+}
+```
+
+Example usage:
+
+```javascript
+const parser = require('typescript-estree');
+const code = "const hello: string = 'world';";
+const ast = parser.parse(code, {
+  range: true,
+  loc: true
+});
+```
+
+### version
+
+Exposes the current version of typescript-estree as specified in package.json.
+
+Example usage:
+
+```javascript
+const parser = require('typescript-estree');
+const version = parser.version;
+```
+
+### AST_NODE_TYPES
+
+Exposes an object that contains the AST node types produced by the parser.
+
+Example usage:
+
+```javascript
+const parser = require('typescript-estree');
+const astNodeTypes = parser.AST_NODE_TYPES;
+```
 
 ## Supported TypeScript Version
 

--- a/parser.js
+++ b/parser.js
@@ -35,10 +35,8 @@ function resetExtra() {
     loc: false,
     comment: false,
     comments: [],
-    tolerant: false,
-    errors: [],
     strict: false,
-    ecmaFeatures: {},
+    jsx: false,
     useJSXTextNode: false,
     log: console.log
   };
@@ -67,31 +65,27 @@ function generateAST(code, options) {
     extra.range = typeof options.range === 'boolean' && options.range;
     extra.loc = typeof options.loc === 'boolean' && options.loc;
 
-    if (extra.loc && options.source !== null && options.source !== undefined) {
-      extra.source = toString(options.source);
-    }
-
     if (typeof options.tokens === 'boolean' && options.tokens) {
       extra.tokens = [];
     }
+
     if (typeof options.comment === 'boolean' && options.comment) {
       extra.comment = true;
       extra.comments = [];
     }
-    if (typeof options.tolerant === 'boolean' && options.tolerant) {
-      extra.errors = [];
-    }
 
-    if (options.ecmaFeatures && typeof options.ecmaFeatures === 'object') {
-      // pass through jsx option
-      extra.ecmaFeatures.jsx = options.ecmaFeatures.jsx;
+    if (typeof options.jsx === 'boolean' && options.jsx) {
+      extra.jsx = true;
     }
 
     /**
      * Allow the user to cause the parser to error if it encounters an unknown AST Node Type
      * (used in testing).
      */
-    if (options.errorOnUnknownASTType) {
+    if (
+      typeof options.errorOnUnknownASTType === 'boolean' &&
+      options.errorOnUnknownASTType
+    ) {
       extra.errorOnUnknownASTType = true;
     }
 
@@ -126,7 +120,7 @@ function generateAST(code, options) {
 
   // Even if jsx option is set in typescript compiler, filename still has to
   // contain .tsx file extension
-  const FILENAME = extra.ecmaFeatures.jsx ? 'estree.tsx' : 'estree.ts';
+  const FILENAME = extra.jsx ? 'estree.tsx' : 'estree.ts';
 
   const compilerHost = {
     fileExists() {
@@ -165,7 +159,7 @@ function generateAST(code, options) {
     {
       noResolve: true,
       target: ts.ScriptTarget.Latest,
-      jsx: extra.ecmaFeatures.jsx ? 'preserve' : undefined
+      jsx: extra.jsx ? 'preserve' : undefined
     },
     compilerHost
   );

--- a/tests/ast-alignment/parse.js
+++ b/tests/ast-alignment/parse.js
@@ -54,9 +54,7 @@ function parseWithTypeScriptESTree(text, parserOptions) {
           comment: false,
           useJSXTextNode: true,
           errorOnUnknownASTType: true,
-          ecmaFeatures: {
-            jsx: true
-          }
+          jsx: true
         },
         parserOptions
       )

--- a/tests/lib/__snapshots__/ecma-features.js.snap
+++ b/tests/lib/__snapshots__/ecma-features.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ecmaFeatures fixtures/arrayLiteral/array-literal-in-lhs.src 1`] = `
+exports[`ecma-features fixtures/arrayLiteral/array-literal-in-lhs.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -349,7 +349,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrayLiteral/array-literals-in-binary-expr.src 1`] = `
+exports[`ecma-features fixtures/arrayLiteral/array-literals-in-binary-expr.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -553,7 +553,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/as-param.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/as-param.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -834,7 +834,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/as-param-with-params.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/as-param-with-params.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -1206,7 +1206,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/basic.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/basic.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -1379,7 +1379,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/basic-in-binary-expression.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/basic-in-binary-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -2062,7 +2062,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/block-body.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/block-body.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -2326,7 +2326,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/block-body-not-object.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/block-body-not-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -2643,7 +2643,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-dup-params.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-dup-params.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -2907,17 +2907,17 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-missing-paren.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/arrowFunctions/error-missing-paren.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-not-arrow.src 1`] = `"Expression expected."`;
+exports[`ecma-features fixtures/arrowFunctions/error-not-arrow.src 1`] = `"Expression expected."`;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-numeric-param.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/arrowFunctions/error-numeric-param.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-numeric-param-multi.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/arrowFunctions/error-numeric-param-multi.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-reverse-arrow.src 1`] = `"Expression expected."`;
+exports[`ecma-features fixtures/arrowFunctions/error-reverse-arrow.src 1`] = `"Expression expected."`;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-default-param-eval.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-default-param-eval.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -3271,7 +3271,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-dup-params.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-dup-params.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -3607,7 +3607,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-eval.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-eval.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -3943,7 +3943,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-eval-return.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-eval-return.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -4207,7 +4207,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-octal.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-octal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -4489,7 +4489,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-param-arguments.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-param-arguments.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -4825,7 +4825,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-param-eval.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-param-eval.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -5161,7 +5161,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-param-names.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-param-names.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -5497,7 +5497,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-param-no-paren-arguments.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-param-no-paren-arguments.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -5743,7 +5743,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-strict-param-no-paren-eval.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-strict-param-no-paren-eval.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -5989,7 +5989,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-two-lines.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/error-two-lines.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -6254,9 +6254,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/error-wrapped-param.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/arrowFunctions/error-wrapped-param.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/expression.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -6465,7 +6465,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/iife.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/iife.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -6805,7 +6805,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/multiple-params.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/multiple-params.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -7069,7 +7069,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/no-auto-return.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/no-auto-return.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -7423,7 +7423,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/not-strict-arguments.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/not-strict-arguments.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -7597,7 +7597,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/not-strict-eval.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/not-strict-eval.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -7771,7 +7771,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/not-strict-eval-params.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/not-strict-eval-params.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -8035,7 +8035,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/not-strict-octal.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/not-strict-octal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -8245,7 +8245,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/return-arrow-function.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/return-arrow-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -8496,7 +8496,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/return-sequence.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/return-sequence.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -9071,7 +9071,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/single-param.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/single-param.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -9245,7 +9245,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/single-param-parens.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/single-param-parens.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -9455,7 +9455,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/arrowFunctions/single-param-return-identifier.src 1`] = `
+exports[`ecma-features fixtures/arrowFunctions/single-param-return-identifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -9664,9 +9664,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/binaryLiterals/invalid.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/binaryLiterals/invalid.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/binaryLiterals/lowercase.src 1`] = `
+exports[`ecma-features fixtures/binaryLiterals/lowercase.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -9763,7 +9763,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/binaryLiterals/uppercase.src 1`] = `
+exports[`ecma-features fixtures/binaryLiterals/uppercase.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -9860,7 +9860,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/blockBindings/const.src 1`] = `
+exports[`ecma-features fixtures/blockBindings/const.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -10048,7 +10048,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/blockBindings/let.src 1`] = `
+exports[`ecma-features fixtures/blockBindings/let.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -10236,7 +10236,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/blockBindings/let-in-switchcase.src 1`] = `
+exports[`ecma-features fixtures/blockBindings/let-in-switchcase.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -10716,7 +10716,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-accessor-properties.src 1`] = `
+exports[`ecma-features fixtures/classes/class-accessor-properties.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -11330,7 +11330,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-computed-static-method.src 1`] = `
+exports[`ecma-features fixtures/classes/class-computed-static-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -11757,7 +11757,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-expression.src 1`] = `
+exports[`ecma-features fixtures/classes/class-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -11944,7 +11944,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-method-named-prototype.src 1`] = `
+exports[`ecma-features fixtures/classes/class-method-named-prototype.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -12299,7 +12299,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-method-named-static.src 1`] = `
+exports[`ecma-features fixtures/classes/class-method-named-static.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -12672,7 +12672,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-method-named-with-space.src 1`] = `
+exports[`ecma-features fixtures/classes/class-method-named-with-space.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -12992,7 +12992,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-one-method.src 1`] = `
+exports[`ecma-features fixtures/classes/class-one-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -13347,7 +13347,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-one-method-super.src 1`] = `
+exports[`ecma-features fixtures/classes/class-one-method-super.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -13827,7 +13827,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-static-method.src 1`] = `
+exports[`ecma-features fixtures/classes/class-static-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -14218,7 +14218,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-static-method-named-prototype.src 1`] = `
+exports[`ecma-features fixtures/classes/class-static-method-named-prototype.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -14628,7 +14628,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-static-method-named-static.src 1`] = `
+exports[`ecma-features fixtures/classes/class-static-method-named-static.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -15019,7 +15019,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-static-methods-and-accessor-properties.src 1`] = `
+exports[`ecma-features fixtures/classes/class-static-methods-and-accessor-properties.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -15837,7 +15837,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-computed-static-methods.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-computed-static-methods.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -16486,7 +16486,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-methods.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-methods.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -17009,7 +17009,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-methods-computed-constructor.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-methods-computed-constructor.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -17570,7 +17570,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-methods-semi.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-methods-semi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -18111,7 +18111,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-methods-three-semi.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-methods-three-semi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -18688,7 +18688,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-methods-two-semi.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-methods-two-semi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -19247,7 +19247,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-two-static-methods-named-constructor.src 1`] = `
+exports[`ecma-features fixtures/classes/class-two-static-methods-named-constructor.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -19806,7 +19806,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-with-constructor.src 1`] = `
+exports[`ecma-features fixtures/classes/class-with-constructor.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -20161,7 +20161,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-with-constructor-parameters.src 1`] = `
+exports[`ecma-features fixtures/classes/class-with-constructor-parameters.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -20572,7 +20572,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/class-with-constructor-with-space.src 1`] = `
+exports[`ecma-features fixtures/classes/class-with-constructor-with-space.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -20927,7 +20927,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/derived-class-assign-to-var.src 1`] = `
+exports[`ecma-features fixtures/classes/derived-class-assign-to-var.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -21259,7 +21259,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/derived-class-expression.src 1`] = `
+exports[`ecma-features fixtures/classes/derived-class-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -21500,7 +21500,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/empty-class.src 1`] = `
+exports[`ecma-features fixtures/classes/empty-class.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -21686,7 +21686,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/empty-class-double-semi.src 1`] = `
+exports[`ecma-features fixtures/classes/empty-class-double-semi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -21872,7 +21872,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/empty-class-semi.src 1`] = `
+exports[`ecma-features fixtures/classes/empty-class-semi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -22076,7 +22076,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/empty-literal-derived-class.src 1`] = `
+exports[`ecma-features fixtures/classes/empty-literal-derived-class.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -22316,7 +22316,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/invalid-class-declaration.src 1`] = `
+exports[`ecma-features fixtures/classes/invalid-class-declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -22467,7 +22467,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/invalid-class-setter-declaration.src 1`] = `
+exports[`ecma-features fixtures/classes/invalid-class-setter-declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -22840,9 +22840,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/invalid-class-two-super-classes.src 1`] = `"Classes can only extend a single class."`;
+exports[`ecma-features fixtures/classes/invalid-class-two-super-classes.src 1`] = `"Classes can only extend a single class."`;
 
-exports[`ecmaFeatures fixtures/classes/named-class-expression.src 1`] = `
+exports[`ecma-features fixtures/classes/named-class-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -23064,7 +23064,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/classes/named-derived-class-expression.src 1`] = `
+exports[`ecma-features fixtures/classes/named-derived-class-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -23340,7 +23340,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/defaultParams/class-constructor.src 1`] = `
+exports[`ecma-features fixtures/defaultParams/class-constructor.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -23769,7 +23769,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/defaultParams/class-method.src 1`] = `
+exports[`ecma-features fixtures/defaultParams/class-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -24198,7 +24198,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/defaultParams/declaration.src 1`] = `
+exports[`ecma-features fixtures/defaultParams/declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -24497,7 +24497,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/defaultParams/expression.src 1`] = `
+exports[`ecma-features fixtures/defaultParams/expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -24850,7 +24850,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/defaultParams/method.src 1`] = `
+exports[`ecma-features fixtures/defaultParams/method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -25333,7 +25333,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/defaultParams/not-all-params.src 1`] = `
+exports[`ecma-features fixtures/defaultParams/not-all-params.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -25832,7 +25832,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/array-member.src 1`] = `
+exports[`ecma-features fixtures/destructuring/array-member.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -26128,7 +26128,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/array-to-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/array-to-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -26514,7 +26514,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/array-var-undefined.src 1`] = `
+exports[`ecma-features fixtures/destructuring/array-var-undefined.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -26775,7 +26775,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-constructor-params-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-constructor-params-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -27241,7 +27241,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-constructor-params-defaults-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-constructor-params-defaults-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -27851,7 +27851,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-constructor-params-defaults-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-constructor-params-defaults-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -28539,7 +28539,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-constructor-params-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-constructor-params-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -29083,7 +29083,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-method-params-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-method-params-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -29549,7 +29549,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-method-params-defaults-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-method-params-defaults-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -30159,7 +30159,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-method-params-defaults-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-method-params-defaults-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -30847,7 +30847,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/class-method-params-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/class-method-params-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -31391,7 +31391,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -31668,7 +31668,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-array-all.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-array-all.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -32235,7 +32235,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-array-longform-nested-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-array-longform-nested-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -33013,7 +33013,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-array-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-array-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -33436,7 +33436,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-array-nested-all.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-array-nested-all.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -33932,7 +33932,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-array-nested-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-array-nested-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -34356,7 +34356,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -34692,7 +34692,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-all.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-all.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -35376,7 +35376,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-longform.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-longform.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -35766,7 +35766,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-longform-all.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-longform-all.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -36558,7 +36558,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-longform-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-longform-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -37206,7 +37206,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-mixed-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-mixed-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -37782,7 +37782,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -38322,7 +38322,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-nested-all.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-nested-all.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -38971,7 +38971,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/defaults-object-nested-multi.src 1`] = `
+exports[`ecma-features fixtures/destructuring/defaults-object-nested-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -39548,7 +39548,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/destructured-array-catch.src 1`] = `
+exports[`ecma-features fixtures/destructuring/destructured-array-catch.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -40469,7 +40469,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/destructured-object-catch.src 1`] = `
+exports[`ecma-features fixtures/destructuring/destructured-object-catch.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -41429,7 +41429,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/invalid-defaults-object-assign.src 1`] = `
+exports[`ecma-features fixtures/destructuring/invalid-defaults-object-assign.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -41964,7 +41964,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/named-param.src 1`] = `
+exports[`ecma-features fixtures/destructuring/named-param.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -42298,7 +42298,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/nested-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/nested-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -42964,7 +42964,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/nested-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/nested-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -43932,7 +43932,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/object-var-named.src 1`] = `
+exports[`ecma-features fixtures/destructuring/object-var-named.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -44268,7 +44268,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/object-var-undefined.src 1`] = `
+exports[`ecma-features fixtures/destructuring/object-var-undefined.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -44568,7 +44568,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/param-defaults-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/param-defaults-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -44922,7 +44922,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/param-defaults-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/param-defaults-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -45315,7 +45315,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/param-defaults-object-nested.src 1`] = `
+exports[`ecma-features fixtures/destructuring/param-defaults-object-nested.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -46038,7 +46038,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -46409,7 +46409,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-array-wrapped.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-array-wrapped.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -46816,7 +46816,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-multi-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-multi-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -47226,7 +47226,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-nested-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-nested-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -47690,7 +47690,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-nested-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-nested-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -48341,7 +48341,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -48790,7 +48790,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/params-object-wrapped.src 1`] = `
+exports[`ecma-features fixtures/destructuring/params-object-wrapped.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -49275,7 +49275,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring/sparse-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring/sparse-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -49571,7 +49571,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/arrow-param-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/arrow-param-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -49835,7 +49835,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/arrow-param-nested-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/arrow-param-nested-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -50208,7 +50208,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/arrow-param-nested-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/arrow-param-nested-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -50734,7 +50734,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/arrow-param-nested-object-named.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/arrow-param-nested-object-named.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -51332,7 +51332,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/arrow-param-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/arrow-param-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -51635,7 +51635,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/param-defaults-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/param-defaults-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -51953,7 +51953,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/param-defaults-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/param-defaults-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -52310,7 +52310,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-arrowFunctions/param-defaults-object-nested.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-arrowFunctions/param-defaults-object-nested.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -53071,7 +53071,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-blockBindings/array-const-undefined.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-blockBindings/array-const-undefined.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -53332,7 +53332,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-blockBindings/array-let-undefined.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-blockBindings/array-let-undefined.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -53593,7 +53593,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-blockBindings/object-const-named.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-blockBindings/object-const-named.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -53929,7 +53929,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-blockBindings/object-const-undefined.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-blockBindings/object-const-undefined.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -54229,7 +54229,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-blockBindings/object-let-named.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-blockBindings/object-let-named.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -54565,7 +54565,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-blockBindings/object-let-undefined.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-blockBindings/object-let-undefined.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -54865,7 +54865,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-defaultParams/param-array.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-defaultParams/param-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -55309,7 +55309,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-defaultParams/param-object.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-defaultParams/param-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -55904,7 +55904,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-defaultParams/param-object-short.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-defaultParams/param-object-short.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -56557,7 +56557,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-forOf/loop.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-forOf/loop.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -56834,7 +56834,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/complex-destructured.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/complex-destructured.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -57333,7 +57333,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/destructured-array-literal.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/destructured-array-literal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -57754,7 +57754,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/destructuring-param.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/destructuring-param.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -58269,7 +58269,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/error-complex-destructured-spread-first.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/error-complex-destructured-spread-first.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -58768,7 +58768,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/multi-destructured.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/multi-destructured.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -59080,7 +59080,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/single-destructured.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/single-destructured.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -59338,7 +59338,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/var-complex-destructured.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/var-complex-destructured.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -59857,7 +59857,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/var-destructured-array-literal.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/var-destructured-array-literal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -60298,7 +60298,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/var-multi-destructured.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/var-multi-destructured.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -60630,7 +60630,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/destructuring-and-spread/var-single-destructured.src 1`] = `
+exports[`ecma-features fixtures/destructuring-and-spread/var-single-destructured.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -60908,7 +60908,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalAsyncIteration/async-generators.src 1`] = `
+exports[`ecma-features fixtures/experimentalAsyncIteration/async-generators.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -61134,7 +61134,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalAsyncIteration/async-iterator.src 1`] = `
+exports[`ecma-features fixtures/experimentalAsyncIteration/async-iterator.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -61633,7 +61633,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalDynamicImport/dynamic-import.src 1`] = `
+exports[`ecma-features fixtures/experimentalDynamicImport/dynamic-import.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -61983,7 +61983,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/arg-spread.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/arg-spread.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -62393,7 +62393,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/destructuring-assign-mirror.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/destructuring-assign-mirror.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -62945,7 +62945,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/function-parameter-object-spread.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/function-parameter-object-spread.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -63262,9 +63262,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/invalid-rest.src 1`] = `"',' expected."`;
+exports[`ecma-features fixtures/experimentalObjectRestSpread/invalid-rest.src 1`] = `"',' expected."`;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/invalid-rest-trailing-comma.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/invalid-rest-trailing-comma.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -63746,7 +63746,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/object-rest.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/object-rest.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -64731,7 +64731,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/property-spread.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/property-spread.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -65593,7 +65593,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/shorthand-method-args.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/shorthand-method-args.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -66226,7 +66226,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/shorthand-methods.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/shorthand-methods.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -66915,7 +66915,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/shorthand-properties.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/shorthand-properties.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -67633,7 +67633,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/single-spread.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/single-spread.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -68423,7 +68423,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/spread-trailing-comma.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/spread-trailing-comma.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -68831,7 +68831,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalObjectRestSpread/two-spread.src 1`] = `
+exports[`ecma-features fixtures/experimentalObjectRestSpread/two-spread.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -69581,7 +69581,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalOptionalCatchBinding/optional-catch-binding.src 1`] = `
+exports[`ecma-features fixtures/experimentalOptionalCatchBinding/optional-catch-binding.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -69786,7 +69786,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/experimentalOptionalCatchBinding/optional-catch-binding-finally.src 1`] = `
+exports[`ecma-features fixtures/experimentalOptionalCatchBinding/optional-catch-binding-finally.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -70062,7 +70062,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/exponentiationOperators/exponential-operators.src 1`] = `
+exports[`ecma-features fixtures/exponentiationOperators/exponential-operators.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -70468,7 +70468,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/forOf/for-of-with-function-initializer.src 1`] = `
+exports[`ecma-features fixtures/forOf/for-of-with-function-initializer.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -71183,7 +71183,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/forOf/for-of-with-var-and-braces.src 1`] = `
+exports[`ecma-features fixtures/forOf/for-of-with-var-and-braces.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -71606,7 +71606,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/forOf/for-of-with-var-and-no-braces.src 1`] = `
+exports[`ecma-features fixtures/forOf/for-of-with-var-and-no-braces.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -71974,7 +71974,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/forOf/invalid-for-of-with-const-and-no-braces.src 1`] = `
+exports[`ecma-features fixtures/forOf/invalid-for-of-with-const-and-no-braces.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -72342,7 +72342,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/forOf/invalid-for-of-with-let-and-no-braces.src 1`] = `
+exports[`ecma-features fixtures/forOf/invalid-for-of-with-let-and-no-braces.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -72710,7 +72710,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/anonymous-generator.src 1`] = `
+exports[`ecma-features fixtures/generators/anonymous-generator.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -73044,7 +73044,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/async-generator-function.src 1`] = `
+exports[`ecma-features fixtures/generators/async-generator-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -73270,7 +73270,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/async-generator-method.src 1`] = `
+exports[`ecma-features fixtures/generators/async-generator-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -73898,7 +73898,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/double-yield.src 1`] = `
+exports[`ecma-features fixtures/generators/double-yield.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -74269,7 +74269,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/empty-generator-declaration.src 1`] = `
+exports[`ecma-features fixtures/generators/empty-generator-declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -74512,7 +74512,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/generator-declaration.src 1`] = `
+exports[`ecma-features fixtures/generators/generator-declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -74863,7 +74863,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/yield-delegation.src 1`] = `
+exports[`ecma-features fixtures/generators/yield-delegation.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -75215,7 +75215,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/yield-without-value.src 1`] = `
+exports[`ecma-features fixtures/generators/yield-without-value.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -75532,7 +75532,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/yield-without-value-in-call.src 1`] = `
+exports[`ecma-features fixtures/generators/yield-without-value-in-call.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -75940,7 +75940,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/generators/yield-without-value-no-semi.src 1`] = `
+exports[`ecma-features fixtures/generators/yield-without-value-no-semi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -76239,7 +76239,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/globalReturn/return-identifier.src 1`] = `
+exports[`ecma-features fixtures/globalReturn/return-identifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -76353,7 +76353,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/globalReturn/return-no-arg.src 1`] = `
+exports[`ecma-features fixtures/globalReturn/return-no-arg.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -76432,7 +76432,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/globalReturn/return-true.src 1`] = `
+exports[`ecma-features fixtures/globalReturn/return-true.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -76547,7 +76547,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/importMeta/simple-import-meta.src 1`] = `
+exports[`ecma-features fixtures/importMeta/simple-import-meta.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -76786,7 +76786,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/error-delete.src 1`] = `
+exports[`ecma-features fixtures/modules/error-delete.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -77082,7 +77082,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/error-function.src 1`] = `
+exports[`ecma-features fixtures/modules/error-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -77380,7 +77380,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/error-strict.src 1`] = `
+exports[`ecma-features fixtures/modules/error-strict.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -77964,7 +77964,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-array.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-array.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -78114,7 +78114,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-class.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-class.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -78283,7 +78283,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-expression.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -78525,7 +78525,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-function.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -78733,7 +78733,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-named-class.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-named-class.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -78937,7 +78937,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-named-function.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-named-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -79180,7 +79180,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-number.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-number.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -79313,7 +79313,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-object.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-object.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -79576,7 +79576,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-default-value.src 1`] = `
+exports[`ecma-features fixtures/modules/export-default-value.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -79708,7 +79708,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-batch.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-batch.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -79859,7 +79859,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-default.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-default.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -80102,7 +80102,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-named-as-default.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-named-as-default.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -80381,7 +80381,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-named-as-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-named-as-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -80660,7 +80660,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-named-as-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-named-as-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -81028,7 +81028,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -81271,7 +81271,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-from-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/export-from-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -81603,7 +81603,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-function.src 1`] = `
+exports[`ecma-features fixtures/modules/export-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -81830,7 +81830,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-as-default.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-as-default.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -82055,7 +82055,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-as-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-as-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -82280,7 +82280,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-as-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-as-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -82594,7 +82594,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-class.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-class.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -82782,7 +82782,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-empty.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-empty.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -82899,7 +82899,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -83088,7 +83088,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -83366,7 +83366,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-named-specifiers-comma.src 1`] = `
+exports[`ecma-features fixtures/modules/export-named-specifiers-comma.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -83662,7 +83662,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-var.src 1`] = `
+exports[`ecma-features fixtures/modules/export-var.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -83834,7 +83834,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-var-anonymous-function.src 1`] = `
+exports[`ecma-features fixtures/modules/export-var-anonymous-function.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -84153,7 +84153,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/export-var-number.src 1`] = `
+exports[`ecma-features fixtures/modules/export-var-number.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -84379,7 +84379,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-default.src 1`] = `
+exports[`ecma-features fixtures/modules/import-default.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -84567,7 +84567,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-default-and-named-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/import-default-and-named-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -84880,7 +84880,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-default-and-namespace-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/import-default-and-namespace-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -85175,7 +85175,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-default-as.src 1`] = `
+exports[`ecma-features fixtures/modules/import-default-as.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -85453,7 +85453,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-jquery.src 1`] = `
+exports[`ecma-features fixtures/modules/import-jquery.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -85623,7 +85623,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-module.src 1`] = `
+exports[`ecma-features fixtures/modules/import-module.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -85739,7 +85739,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-named-as-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/import-named-as-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -86017,7 +86017,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-named-as-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/import-named-as-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -86384,7 +86384,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-named-empty.src 1`] = `
+exports[`ecma-features fixtures/modules/import-named-empty.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -86554,7 +86554,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-named-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/import-named-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -86796,7 +86796,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-named-specifiers.src 1`] = `
+exports[`ecma-features fixtures/modules/import-named-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -87127,7 +87127,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-named-specifiers-comma.src 1`] = `
+exports[`ecma-features fixtures/modules/import-named-specifiers-comma.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -87476,7 +87476,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-namespace-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/import-namespace-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -87700,7 +87700,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/import-null-as-nil.src 1`] = `
+exports[`ecma-features fixtures/modules/import-null-as-nil.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -87960,7 +87960,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/invalid-await.src 1`] = `
+exports[`ecma-features fixtures/modules/invalid-await.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -88132,7 +88132,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/invalid-class.src 1`] = `
+exports[`ecma-features fixtures/modules/invalid-class.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -88301,17 +88301,17 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-batch-missing-from-clause.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-batch-missing-from-clause.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-batch-token.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-batch-token.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-default.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-default.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-default-equal.src 1`] = `"Expression expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-default-equal.src 1`] = `"Expression expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-default-token.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-default-token.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-named-default.src 1`] = `
+exports[`ecma-features fixtures/modules/invalid-export-named-default.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -88482,19 +88482,19 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-named-extra-comma.src 1`] = `"Identifier expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-named-extra-comma.src 1`] = `"Identifier expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-export-named-middle-comma.src 1`] = `"Identifier expected."`;
+exports[`ecma-features fixtures/modules/invalid-export-named-middle-comma.src 1`] = `"Identifier expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-default.src 1`] = `"Expression expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-default.src 1`] = `"Expression expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-default-after-named.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-default-after-named.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-default-after-named-after-default.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-default-after-named-after-default.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-default-missing-module-specifier.src 1`] = `"'=' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-default-missing-module-specifier.src 1`] = `"'=' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-default-module-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/invalid-import-default-module-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -88681,9 +88681,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-missing-module-specifier.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-missing-module-specifier.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-module-specifier.src 1`] = `
+exports[`ecma-features fixtures/modules/invalid-import-module-specifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -88907,21 +88907,21 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-named-after-named.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-named-after-named.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-named-after-namespace.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-named-after-namespace.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-named-as-missing-from.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-named-as-missing-from.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-named-extra-comma.src 1`] = `"Identifier expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-named-extra-comma.src 1`] = `"Identifier expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-named-middle-comma.src 1`] = `"Identifier expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-named-middle-comma.src 1`] = `"Identifier expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-namespace-after-named.src 1`] = `"'from' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-namespace-after-named.src 1`] = `"'from' expected."`;
 
-exports[`ecmaFeatures fixtures/modules/invalid-import-namespace-missing-as.src 1`] = `"'as' expected."`;
+exports[`ecma-features fixtures/modules/invalid-import-namespace-missing-as.src 1`] = `"'as' expected."`;
 
-exports[`ecmaFeatures fixtures/newTarget/invalid-new-target.src 1`] = `
+exports[`ecma-features fixtures/newTarget/invalid-new-target.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -89180,7 +89180,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/newTarget/invalid-unknown-property.src 1`] = `
+exports[`ecma-features fixtures/newTarget/invalid-unknown-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -89587,7 +89587,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/newTarget/simple-new-target.src 1`] = `
+exports[`ecma-features fixtures/newTarget/simple-new-target.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -90012,7 +90012,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteral/object-literal-in-lhs.src 1`] = `
+exports[`ecma-features fixtures/objectLiteral/object-literal-in-lhs.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -90361,7 +90361,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/computed-addition-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/computed-addition-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -90789,7 +90789,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/computed-and-identifier.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/computed-and-identifier.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -91218,7 +91218,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/computed-getter-and-setter.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/computed-getter-and-setter.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -91870,7 +91870,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/computed-string-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/computed-string-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -92225,7 +92225,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/computed-variable-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/computed-variable-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -92579,11 +92579,11 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/invalid-computed-variable-property.src 1`] = `"':' expected."`;
+exports[`ecma-features fixtures/objectLiteralComputedProperties/invalid-computed-variable-property.src 1`] = `"':' expected."`;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/invalid-standalone-computed-variable-property.src 1`] = `"':' expected."`;
+exports[`ecma-features fixtures/objectLiteralComputedProperties/invalid-standalone-computed-variable-property.src 1`] = `"':' expected."`;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/standalone-expression.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/standalone-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -92882,7 +92882,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/standalone-expression-with-addition.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/standalone-expression-with-addition.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -93255,7 +93255,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralComputedProperties/standalone-expression-with-method.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralComputedProperties/standalone-expression-with-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -93647,7 +93647,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralDuplicateProperties/error-proto-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralDuplicateProperties/error-proto-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -94347,7 +94347,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralDuplicateProperties/error-proto-string-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralDuplicateProperties/error-proto-string-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -95049,7 +95049,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralDuplicateProperties/strict-duplicate-properties.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralDuplicateProperties/strict-duplicate-properties.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -95570,7 +95570,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -96093,9 +96093,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/invalid-method-no-braces.src 1`] = `"'{' expected."`;
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/invalid-method-no-braces.src 1`] = `"'{' expected."`;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/method-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/method-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -96561,7 +96561,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/simple-method.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/simple-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -96952,7 +96952,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/simple-method-named-get.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/simple-method-named-get.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -97343,7 +97343,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/simple-method-named-set.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/simple-method-named-set.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -97734,7 +97734,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/simple-method-with-argument.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/simple-method-with-argument.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -98162,7 +98162,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/simple-method-with-string-name.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/simple-method-with-string-name.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -98554,7 +98554,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandMethods/string-name-method-property.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandMethods/string-name-method-property.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -99021,7 +99021,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/objectLiteralShorthandProperties/shorthand-properties.src 1`] = `
+exports[`ecma-features fixtures/objectLiteralShorthandProperties/shorthand-properties.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -99743,9 +99743,9 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/octalLiterals/invalid.src 1`] = `"';' expected."`;
+exports[`ecma-features fixtures/octalLiterals/invalid.src 1`] = `"';' expected."`;
 
-exports[`ecmaFeatures fixtures/octalLiterals/lowercase.src 1`] = `
+exports[`ecma-features fixtures/octalLiterals/lowercase.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -99842,7 +99842,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/octalLiterals/strict-uppercase.src 1`] = `
+exports[`ecma-features fixtures/octalLiterals/strict-uppercase.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -100011,7 +100011,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/octalLiterals/uppercase.src 1`] = `
+exports[`ecma-features fixtures/octalLiterals/uppercase.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -100108,7 +100108,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/regex/regexp-simple.src 1`] = `
+exports[`ecma-features fixtures/regex/regexp-simple.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -100305,7 +100305,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/regexUFlag/regex-u-extended-escape.src 1`] = `
+exports[`ecma-features fixtures/regexUFlag/regex-u-extended-escape.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -100502,7 +100502,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/regexUFlag/regex-u-invalid-extended-escape.src 1`] = `
+exports[`ecma-features fixtures/regexUFlag/regex-u-invalid-extended-escape.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -100699,7 +100699,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/regexUFlag/regex-u-simple.src 1`] = `
+exports[`ecma-features fixtures/regexUFlag/regex-u-simple.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -100896,7 +100896,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/regexYFlag/regexp-y-simple.src 1`] = `
+exports[`ecma-features fixtures/regexYFlag/regexp-y-simple.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -101093,7 +101093,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/basic-rest.src 1`] = `
+exports[`ecma-features fixtures/restParams/basic-rest.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -101444,7 +101444,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/class-constructor.src 1`] = `
+exports[`ecma-features fixtures/restParams/class-constructor.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -101836,7 +101836,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/class-method.src 1`] = `
+exports[`ecma-features fixtures/restParams/class-method.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -102228,7 +102228,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/error-no-default.src 1`] = `
+exports[`ecma-features fixtures/restParams/error-no-default.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -102545,7 +102545,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/error-not-last.src 1`] = `
+exports[`ecma-features fixtures/restParams/error-not-last.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -102880,7 +102880,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/func-expression.src 1`] = `
+exports[`ecma-features fixtures/restParams/func-expression.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -103234,7 +103234,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/func-expression-multi.src 1`] = `
+exports[`ecma-features fixtures/restParams/func-expression-multi.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -103642,7 +103642,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/invalid-rest-param.src 1`] = `
+exports[`ecma-features fixtures/restParams/invalid-rest-param.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -104033,7 +104033,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/restParams/single-rest.src 1`] = `
+exports[`ecma-features fixtures/restParams/single-rest.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -104330,11 +104330,11 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/spread/error-invalid-if.src 1`] = `"Expression expected."`;
+exports[`ecma-features fixtures/spread/error-invalid-if.src 1`] = `"Expression expected."`;
 
-exports[`ecmaFeatures fixtures/spread/error-invalid-sequence.src 1`] = `"Expression expected."`;
+exports[`ecma-features fixtures/spread/error-invalid-sequence.src 1`] = `"Expression expected."`;
 
-exports[`ecmaFeatures fixtures/spread/multi-function-call.src 1`] = `
+exports[`ecma-features fixtures/spread/multi-function-call.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -104610,7 +104610,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/spread/not-final-param.src 1`] = `
+exports[`ecma-features fixtures/spread/not-final-param.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -104886,7 +104886,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/spread/simple-function-call.src 1`] = `
+exports[`ecma-features fixtures/spread/simple-function-call.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -105108,7 +105108,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/deeply-nested.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/deeply-nested.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -105573,7 +105573,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/error-octal-literal.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/error-octal-literal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -105693,7 +105693,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/escape-characters.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/escape-characters.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -105907,7 +105907,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/expressions.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/expressions.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -106581,7 +106581,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/multi-line-template-string.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/multi-line-template-string.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -106716,7 +106716,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/simple-template-string.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/simple-template-string.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -106836,7 +106836,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/single-dollar-sign.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/single-dollar-sign.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -107048,7 +107048,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/tagged-no-placeholders.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/tagged-no-placeholders.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -107221,7 +107221,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/templateStrings/tagged-template-string.src 1`] = `
+exports[`ecma-features fixtures/templateStrings/tagged-template-string.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -107947,7 +107947,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/unicodeCodePointEscapes/basic-string-literal.src 1`] = `
+exports[`ecma-features fixtures/unicodeCodePointEscapes/basic-string-literal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -108044,7 +108044,7 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/unicodeCodePointEscapes/complex-string-literal.src 1`] = `
+exports[`ecma-features fixtures/unicodeCodePointEscapes/complex-string-literal.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -108141,6 +108141,6 @@ Object {
 }
 `;
 
-exports[`ecmaFeatures fixtures/unicodeCodePointEscapes/invalid-empty-escape.src 1`] = `"Hexadecimal digit expected."`;
+exports[`ecma-features fixtures/unicodeCodePointEscapes/invalid-empty-escape.src 1`] = `"Hexadecimal digit expected."`;
 
-exports[`ecmaFeatures fixtures/unicodeCodePointEscapes/invalid-too-large-escape.src 1`] = `"An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive."`;
+exports[`ecma-features fixtures/unicodeCodePointEscapes/invalid-too-large-escape.src 1`] = `"An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive."`;

--- a/tests/lib/basics.js
+++ b/tests/lib/basics.js
@@ -36,14 +36,11 @@ const testFiles = shelljs
 
 describe('basics', () => {
   testFiles.forEach(filename => {
-    // Uncomment and fill in filename to focus on a single file
-    // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
     const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`);
     const config = {
       loc: true,
       range: true,
       tokens: true,
-      ecmaFeatures: {},
       errorOnUnknownASTType: true
     };
     test(

--- a/tests/lib/comments.js
+++ b/tests/lib/comments.js
@@ -42,9 +42,7 @@ describe('Comments', () => {
       range: true,
       tokens: true,
       comment: true,
-      ecmaFeatures: {
-        jsx: true
-      }
+      jsx: true
     };
     test(
       `fixtures/${filename}.src`,

--- a/tests/lib/ecma-features.js
+++ b/tests/lib/ecma-features.js
@@ -34,22 +34,18 @@ const testFiles = shelljs
 // Tests
 //------------------------------------------------------------------------------
 
-describe('ecmaFeatures', () => {
+describe('ecma-features', () => {
   testFiles.forEach(filename => {
-    // Uncomment and fill in filename to focus on a single file
-    // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
     const feature = path.dirname(filename),
       code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.js`),
       config = {
         loc: true,
         range: true,
         tokens: true,
-        ecmaFeatures: {},
         errorOnUnknownASTType: true
       };
 
     test(`fixtures/${filename}.src`, () => {
-      config.ecmaFeatures[feature] = true;
       testUtils.createSnapshotTestBlock(code, config)();
     });
   });

--- a/tests/lib/jsx.js
+++ b/tests/lib/jsx.js
@@ -57,8 +57,6 @@ describe('JSX', () => {
    */
   function testFixture(fixturesDir, useJSXTextNode) {
     return filename => {
-      // Uncomment and fill in filename to focus on a single file
-      // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
       const code = shelljs.cat(`${path.resolve(fixturesDir, filename)}.src.js`);
 
       const config = {
@@ -67,9 +65,7 @@ describe('JSX', () => {
         tokens: true,
         errorOnUnknownASTType: true,
         useJSXTextNode,
-        ecmaFeatures: {
-          jsx: true
-        }
+        jsx: true
       };
 
       test(

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -40,9 +40,6 @@ describe('parse()', () => {
   describe('general', () => {
     const code = 'let foo = bar;';
     const config = {
-      ecmaFeatures: {
-        blockBindings: true
-      },
       comment: true,
       tokens: true,
       range: true,

--- a/tests/lib/tsx.js
+++ b/tests/lib/tsx.js
@@ -35,8 +35,6 @@ const testFiles = shelljs
 
 describe('TSX', () => {
   testFiles.forEach(filename => {
-    // Uncomment and fill in filename to focus on a single file
-    // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
     const code = shelljs.cat(
       `${path.resolve(TSX_FIXTURES_DIR, filename)}.src.tsx`
     );
@@ -46,9 +44,7 @@ describe('TSX', () => {
       tokens: true,
       errorOnUnknownASTType: true,
       useJSXTextNode: true,
-      ecmaFeatures: {
-        jsx: true
-      }
+      jsx: true
     };
     test(
       `fixtures/${filename}.src`,

--- a/tests/lib/typescript.js
+++ b/tests/lib/typescript.js
@@ -36,14 +36,11 @@ const testFiles = shelljs
 
 describe('typescript', () => {
   testFiles.forEach(filename => {
-    // Uncomment and fill in filename to focus on a single file
-    // var filename = "jsx/invalid-matching-placeholder-in-closing-tag";
     const code = shelljs.cat(`${path.resolve(FIXTURES_DIR, filename)}.src.ts`);
     const config = {
       loc: true,
       range: true,
       tokens: true,
-      ecmaFeatures: {},
       errorOnUnknownASTType: true
     };
     test(


### PR DESCRIPTION
refs https://github.com/JamesHenry/typescript-estree/issues/21

I wanted to document the current API and also to see what others thought of removing the `ecmaFeatures` option, as it feels like a hold-over implementation detail of this project initially being created for ESLint. Now that it's a separate project, I don't think it makes a lot of sense to keep it, and would advocate for individual flags/configuration options to be used as needed. Given that TypeScript itself doesn't provide a lot of syntax-level feature flags, it doesn't seem like this will be needed often, if at all, for syntax features. Removing this here also means that this project doesn't have to keep parity with ESLint's configuration options (since the options are just passed through from `typescript-eslint-parser` at the moment), and instead `typescript-eslint-parser` can just enable feature flags as necessary based on the config it receives.

And just to be clear, `ecmaFeatures.jsx` is currently the only option that is used, so this is a very minimal change.

Both [Prettier](https://github.com/prettier/prettier/blob/master/package.json#L69) and [typescript-eslint-parser]() lock the version of the parser they're using, so making the breaking change and then updating the individual projects should be easy to do (and I'm happy to do the work!). However, if this idea is well-received and there is concern over it being a breaking change, I'm happy to make it backwards-compatible. 

I wasn't sure what two of the options were used for, and would love some guidance on that.