### PR TITLE
chore: test Node v11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
+  - '11'
   - '10'
   - '9'
   - '8'


### PR DESCRIPTION
Now that Node v11 is officially in development, we should probably start testing it.

Ah, sorry - I used the GitHub UI to make this PR and just noticed it made a branch in your repo rather than my fork.