### PR TITLE
feat: typed parser return value

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,7 +8,13 @@
 import semver from 'semver';
 import ts from 'typescript';
 import convert from './ast-converter';
-import { Extra, ParserOptions } from './temp-types-based-on-js-source';
+import {
+  Extra,
+  ParserOptions,
+  ESTreeToken,
+  ESTreeComment
+} from './temp-types-based-on-js-source';
+import { Program } from './estree/spec';
 
 const packageJSON = require('../package.json');
 
@@ -46,13 +52,21 @@ function resetExtra(): void {
 // Parser
 //------------------------------------------------------------------------------
 
+type ParserResult<T extends ParserOptions> = Program &
+  (T['range'] extends true ? { range: [number, number] } : {}) &
+  (T['tokens'] extends true ? { tokens: ESTreeToken[] } : {}) &
+  (T['comment'] extends true ? { comments: ESTreeComment[] } : {});
+
 /**
  * Parses the given source code to produce a valid AST
  * @param {string} code    TypeScript code
  * @param {ParserOptions} options configuration object for the parser
  * @returns {Object}         the AST
  */
-function generateAST(code: string, options: ParserOptions): any {
+function generateAST<T extends ParserOptions = ParserOptions>(
+  code: string,
+  options?: T
+): ParserResult<T> {
   const toString = String;
 
   if (typeof code !== 'string' && !((code as any) instanceof String)) {
@@ -182,6 +196,9 @@ export { version };
 
 const version = packageJSON.version;
 
-export function parse(code: string, options: ParserOptions) {
-  return generateAST(code, options);
+export function parse<T extends ParserOptions = ParserOptions>(
+  code: string,
+  options?: T
+) {
+  return generateAST<T>(code, options);
 }

--- a/src/temp-types-based-on-js-source.ts
+++ b/src/temp-types-based-on-js-source.ts
@@ -69,12 +69,12 @@ export interface Extra {
 }
 
 export interface ParserOptions {
-  range: boolean;
-  loc: boolean;
-  tokens: boolean;
-  comment: boolean;
-  jsx: boolean;
-  errorOnUnknownASTType: boolean;
-  useJSXTextNode: boolean;
-  loggerFn: Function | false;
+  range?: boolean;
+  loc?: boolean;
+  tokens?: boolean;
+  comment?: boolean;
+  jsx?: boolean;
+  errorOnUnknownASTType?: boolean;
+  useJSXTextNode?: boolean;
+  loggerFn?: Function | false;
 }


### PR DESCRIPTION
Previously, type of the return value of `parse` function is `any`. This PR make it strongly typed.

Additions:

- The `options` can be `undefined` now and all the properties of `options` can be `undefined`. That is, all the code below are valid:
```typescript
// We can omit the options:
parse('source code')

// All properties are optional:
parse('source code', {})
```

- The properties of the parser result are dynamic. For example, if you disable the `tokens` option like this:

```typescript
let ast = parse('', { tokens: false })
```

The `tokens` property will not exist in the variable `ast`.

![default](https://user-images.githubusercontent.com/17216317/48298309-58573c80-e4f6-11e8-8bfa-fc5bb0920a54.png)

Instead, if we enable the `tokens` option:

```typescript
let ast = parse('', { tokens: false })
```

![default](https://user-images.githubusercontent.com/17216317/48298333-93597000-e4f6-11e8-843e-a6644ca82aa3.png)

We can find that an additional `tokens` property is existed on the `ast`.