### PR TITLE
feat: align TSModuleDeclaration with babel/eslint

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -2527,6 +2527,9 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
       }
       // apply modifiers first...
       applyModifiersToResult((node as any).modifiers);
+      if (node.flags & ts.NodeFlags.GlobalAugmentation) {
+        result.global = true;
+      }
       // ...then check for exports
       result = nodeUtils.fixExports(node, result as any, ast);
       break;

--- a/src/temp-types-based-on-js-source.ts
+++ b/src/temp-types-based-on-js-source.ts
@@ -32,6 +32,7 @@ export interface ESTreeNode {
   decorators?: any;
   const?: boolean;
   declare?: boolean;
+  global?: boolean;
   modifiers?: any;
   body?: any;
   params?: any;

--- a/tests/fixtures/typescript/namespaces-and-modules/global-module-declaration.src.ts
+++ b/tests/fixtures/typescript/namespaces-and-modules/global-module-declaration.src.ts
@@ -1,0 +1,8 @@
+declare global {
+    declare module global {
+
+    }
+    declare namespace global {
+
+    }
+}

--- a/tests/lib/__snapshots__/typescript.ts.snap
+++ b/tests/lib/__snapshots__/typescript.ts.snap
@@ -66645,6 +66645,447 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/namespaces-and-modules/global-module-declaration.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "body": Object {
+        "body": Array [
+          Object {
+            "body": Object {
+              "body": Array [],
+              "loc": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 26,
+                  "line": 2,
+                },
+              },
+              "range": Array [
+                43,
+                51,
+              ],
+              "type": "TSModuleBlock",
+            },
+            "declare": true,
+            "id": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 25,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 19,
+                  "line": 2,
+                },
+              },
+              "name": "global",
+              "range": Array [
+                36,
+                42,
+              ],
+              "type": "Identifier",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              21,
+              51,
+            ],
+            "type": "TSModuleDeclaration",
+          },
+          Object {
+            "body": Object {
+              "body": Array [],
+              "loc": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 7,
+                },
+                "start": Object {
+                  "column": 29,
+                  "line": 5,
+                },
+              },
+              "range": Array [
+                81,
+                89,
+              ],
+              "type": "TSModuleBlock",
+            },
+            "declare": true,
+            "id": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 28,
+                  "line": 5,
+                },
+                "start": Object {
+                  "column": 22,
+                  "line": 5,
+                },
+              },
+              "name": "global",
+              "range": Array [
+                74,
+                80,
+              ],
+              "type": "Identifier",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 7,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 5,
+              },
+            },
+            "range": Array [
+              56,
+              89,
+            ],
+            "type": "TSModuleDeclaration",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 15,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          15,
+          91,
+        ],
+        "type": "TSModuleBlock",
+      },
+      "declare": true,
+      "global": true,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 8,
+            "line": 1,
+          },
+        },
+        "name": "global",
+        "range": Array [
+          8,
+          14,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        91,
+      ],
+      "type": "TSModuleDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 9,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    92,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        7,
+      ],
+      "type": "Identifier",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        8,
+        14,
+      ],
+      "type": "Keyword",
+      "value": "global",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        15,
+        16,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        28,
+      ],
+      "type": "Identifier",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        29,
+        35,
+      ],
+      "type": "Identifier",
+      "value": "module",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        36,
+        42,
+      ],
+      "type": "Keyword",
+      "value": "global",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        43,
+        44,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        50,
+        51,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        56,
+        63,
+      ],
+      "type": "Identifier",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        64,
+        73,
+      ],
+      "type": "Identifier",
+      "value": "namespace",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        74,
+        80,
+      ],
+      "type": "Keyword",
+      "value": "global",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 29,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        81,
+        82,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        88,
+        89,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        90,
+        91,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/namespaces-and-modules/module-with-default-exports.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
This PR adds optional `global` property to `TSModuleDeclaration` AST in case when
```ts
// Augmentations for the global stuff.
declare global {
}
```

--------

In Babel/Typescript we have

```js
defineType("TSModuleDeclaration", {
  aliases: ["Statement", "Declaration"],
  visitor: ["id", "body"],
  fields: {
    declare: validateOptional(bool),
    global: validateOptional(bool),
    id: validateType(["Identifier", "StringLiteral"]),
    body: validateType(["TSModuleBlock", "TSModuleDeclaration"]),
  },
});
```

fixes: #27, https://github.com/eslint/typescript-eslint-parser/issues/570