### PR TITLE
test: change babel sourceType to unambiguous with FixtureTester

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-2-Clause",
   "devDependencies": {
     "@babel/code-frame": "7.0.0",
-    "@babel/parser": "7.1.6",
+    "@babel/parser": "7.2.3",
     "@commitlint/cli": "^7.1.2",
     "@commitlint/config-conventional": "^7.1.2",
     "@commitlint/travis-cli": "^7.1.2",

--- a/tests/ast-alignment/fixtures-to-test.ts
+++ b/tests/ast-alignment/fixtures-to-test.ts
@@ -20,6 +20,70 @@ interface CreateFixturePatternConfig {
   ignoreSourceType?: string[];
 }
 
+const fixturesDirPath = path.join(__dirname, '../fixtures');
+
+class FixturesTester {
+  protected fixtures: FixturePatternConfig[] = [];
+
+  constructor() {}
+
+  public addFixturePatternConfig(
+    fixturesSubPath: string,
+    config: CreateFixturePatternConfig = {}
+  ) {
+    if (!fs.existsSync(path.join(fixturesDirPath, fixturesSubPath))) {
+      throw new Error(
+        `Registered path '${path.join(
+          __dirname,
+          fixturesSubPath
+        )}' was not found`
+      );
+    }
+
+    const ignore = config.ignore || [];
+    const fileType = config.fileType || 'js';
+    const ignoreSourceType = config.ignoreSourceType || [];
+
+    /**
+     * https://github.com/babel/babel/issues/9213
+     */
+    if (ignoreSourceType.length) {
+      ignore.push(...ignoreSourceType);
+      for (const fixture of ignoreSourceType) {
+        this.fixtures.push({
+          // It needs to be the full path from within fixtures/ for the pattern
+          pattern: `${fixturesSubPath}/${fixture}.src.${config.fileType}`,
+          ignoreSourceType: true
+        });
+      }
+    }
+
+    this.fixtures.push({
+      pattern: `${fixturesSubPath}/!(${ignore.join('|')}).src.${fileType}`,
+      ignoreSourceType: false
+    });
+  }
+
+  protected processFixtures(fixtures: FixturePatternConfig[]): Fixture[] {
+    return fixtures
+      .map(fixtures => {
+        return glob
+          .sync(`${fixturesDirPath}/${fixtures.pattern}`, {})
+          .map(filename => {
+            return {
+              filename,
+              ignoreSourceType: fixtures.ignoreSourceType
+            };
+          });
+      })
+      .reduce((acc, x) => acc.concat(x), []);
+  }
+
+  public getFixtures(): Fixture[] {
+    return this.processFixtures(this.fixtures);
+  }
+}
+
 /**
  * JSX fixtures which have known issues for typescript-estree
  */
@@ -35,457 +99,377 @@ const jsxFilesWithKnownIssues = jsxKnownIssues.map(f => f.replace('jsx/', ''));
 jsxFilesWithKnownIssues.push('invalid-no-tag-name');
 
 /**
- * Globally track which fixtures need to be parsed with sourceType: "module"
- * so that they can be added with the correct FixturePatternConfig
+ * An class with FixturePatternConfigs
  */
-let fixturesRequiringSourceTypeModule: FixturePatternConfig[] = [];
+const tester = new FixturesTester();
 
-/**
- * Utility to generate a FixturePatternConfig object containing the glob pattern for specific subsections of the fixtures/ directory,
- * including the capability to ignore specific nested patterns.
- *
- * @param {string} fixturesSubPath the sub-path within the fixtures/ directory
- * @param {CreateFixturePatternConfig?} config an optional configuration object with optional sub-paths to ignore and/or parse with sourceType: module
- * @returns {FixturePatternConfig} an object containing the glob pattern and optional additional config
- */
-function createFixturePatternConfigFor(
-  fixturesSubPath: string,
-  config?: CreateFixturePatternConfig
-): FixturePatternConfig {
-  if (!fixturesSubPath) {
-    throw new Error(
-      'fixtureSubPath was not provided for the current fixture pattern'
-    );
-  }
-  config = config || ({} as CreateFixturePatternConfig);
-  config.ignore = config.ignore || [];
-  config.fileType = config.fileType || 'js';
-  config.ignoreSourceType = config.ignoreSourceType || [];
-  /**
-   * The TypeScript compiler gives us the "externalModuleIndicator" to allow typescript-estree do dynamically detect the "sourceType".
-   * Babylon does not have an equivalent feature (although perhaps it might come in the future https://github.com/babel/babylon/issues/440),
-   * so we have to specify the "sourceType" we want to use.
-   *
-   * By default we have configured babylon to use "script", but for any fixtures specified in the parseWithSourceTypeModule array we need "module".
-   *
-   * First merge the fixtures which need to be parsed with sourceType: "module" into the
-   * ignore list, and then add their full config into the global array.
-   */
-  if (config.ignoreSourceType.length) {
-    config.ignore = ([] as string[]).concat(
-      config.ignore,
-      config.ignoreSourceType
-    );
-    for (const fixture of config.ignoreSourceType) {
-      fixturesRequiringSourceTypeModule.push({
-        // It needs to be the full path from within fixtures/ for the pattern
-        pattern: `${fixturesSubPath}/${fixture}.src.${config.fileType}`,
-        ignoreSourceType: true
-      });
-    }
-  }
-  return {
-    pattern: `${fixturesSubPath}/!(${config.ignore.join('|')}).src.${
-      config.fileType
-    }`,
-    ignoreSourceType: false
-  };
-}
+tester.addFixturePatternConfig('javascript/basics');
 
-/**
- * An array of FixturePatternConfigs
- */
-let fixturePatternConfigsToTest = [
-  createFixturePatternConfigFor('javascript/basics'),
-
-  createFixturePatternConfigFor('comments', {
-    ignore: [
-      /**
-       * Template strings seem to also be affected by the difference in opinion between different parsers in:
-       * https://github.com/babel/babel/issues/6681
-       */
-      'no-comment-template', // Purely AST diffs
-      'template-string-block' // Purely AST diffs
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/templateStrings', {
-    ignore: ['**/*']
-  }),
-
-  createFixturePatternConfigFor('javascript/experimentalObjectRestSpread', {
-    ignore: [
-      /**
-       * Trailing comma is not permitted after a "RestElement" in Babel
-       */
-      'invalid-rest-trailing-comma'
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/arrowFunctions', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'error-dup-params', // babel parse errors
-      'error-strict-dup-params', // babel parse errors
-      'error-strict-octal', // babel parse errors
-      'error-two-lines' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/bigIntLiterals'),
-  createFixturePatternConfigFor('javascript/binaryLiterals'),
-  createFixturePatternConfigFor('javascript/blockBindings'),
-
-  createFixturePatternConfigFor('javascript/classes', {
-    ignore: [
-      /**
-       * super() is being used outside of constructor. Other parsers (e.g. espree, acorn) do not error on this.
-       */
-      'class-one-method-super', // babel parse errors
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'invalid-class-declaration', // babel parse errors
-      'invalid-class-setter-declaration' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/defaultParams'),
-
-  createFixturePatternConfigFor('javascript/destructuring', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'invalid-defaults-object-assign' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/destructuring-and-arrowFunctions'),
-  createFixturePatternConfigFor('javascript/destructuring-and-blockBindings'),
-  createFixturePatternConfigFor('javascript/destructuring-and-defaultParams'),
-  createFixturePatternConfigFor('javascript/destructuring-and-forOf'),
-
-  createFixturePatternConfigFor('javascript/destructuring-and-spread', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'error-complex-destructured-spread-first' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/experimentalAsyncIteration'),
-  createFixturePatternConfigFor('javascript/experimentalDynamicImport'),
-  createFixturePatternConfigFor('javascript/exponentiationOperators'),
-  createFixturePatternConfigFor('javascript/experimentalOptionalCatchBinding'),
-
-  createFixturePatternConfigFor('javascript/forOf', {
-    ignore: [
-      /**
-       * TypeScript, espree and acorn parse this fine - esprima, flow and babylon do not...
-       */
-      'for-of-with-function-initializer' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/generators'),
-  createFixturePatternConfigFor('javascript/globalReturn'),
-
-  createFixturePatternConfigFor('javascript/modules', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'invalid-export-named-default', // babel parse errors
-      'invalid-import-default-module-specifier', // babel parse errors
-      'invalid-import-module-specifier' // babel parse errors
-    ],
-    ignoreSourceType: ['error-function', 'error-strict', 'error-delete']
-  }),
-
-  createFixturePatternConfigFor('javascript/newTarget', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'invalid-new-target', // babel parse errors
-      'invalid-unknown-property' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/objectLiteral'),
-  createFixturePatternConfigFor('javascript/objectLiteralComputedProperties'),
-
-  createFixturePatternConfigFor('javascript/objectLiteralDuplicateProperties', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'error-proto-property', // babel parse errors
-      'error-proto-string-property' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/objectLiteralShorthandMethods'),
-  createFixturePatternConfigFor('javascript/objectLiteralShorthandProperties'),
-  createFixturePatternConfigFor('javascript/octalLiterals'),
-  createFixturePatternConfigFor('javascript/regex'),
-  createFixturePatternConfigFor('javascript/regexUFlag'),
-  createFixturePatternConfigFor('javascript/regexYFlag'),
-
-  createFixturePatternConfigFor('javascript/restParams', {
-    ignore: [
-      /**
-       * Expected babylon parse errors - all of these files below produce parse errors in espree
-       * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
-       * does not actually error on them and will produce an AST.
-       */
-      'error-no-default', // babel parse errors
-      'error-not-last' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('javascript/spread'),
-  createFixturePatternConfigFor('javascript/unicodeCodePointEscapes'),
-
-  /* ================================================== */
-
-  createFixturePatternConfigFor('jsx', {
-    ignore: jsxFilesWithKnownIssues
-  }),
-  createFixturePatternConfigFor('jsx-useJSXTextNode'),
-
-  /* ================================================== */
-
-  /**
-   * TSX-SPECIFIC FILES
-   */
-
-  createFixturePatternConfigFor('tsx', {
-    fileType: 'tsx'
-  }),
-
-  /* ================================================== */
-
-  /**
-   * TYPESCRIPT-SPECIFIC FILES
-   */
-
-  createFixturePatternConfigFor('typescript/babylon-convergence', {
-    fileType: 'ts'
-  }),
-
-  createFixturePatternConfigFor('typescript/basics', {
-    fileType: 'ts',
-    ignore: [
-      /**
-       * Other babylon parse errors relating to invalid syntax.
-       */
-      'abstract-class-with-abstract-constructor', // babel parse errors
-      'class-with-export-parameter-properties', // babel parse errors
-      'class-with-implements-and-extends', // babel parse errors
-      'class-with-optional-methods', // babel parse errors
-      'class-with-static-parameter-properties', // babel parse errors
-      'interface-with-all-property-types', // babel parse errors
-      'interface-with-construct-signature-with-parameter-accessibility', // babel parse errors
-      /**
-       * typescript-estree erroring, but babylon not.
-       */
-      'arrow-function-with-type-parameters', // typescript-estree parse errors
-      /**
-       * Babylon: ClassDeclaration + abstract: true
-       * tsep: TSAbstractClassDeclaration
-       */
-      'abstract-class-with-abstract-properties',
-      /**
-       * Babylon: ClassProperty + abstract: true
-       * tsep: TSAbstractClassProperty
-       */
-      'abstract-class-with-abstract-readonly-property',
-      /**
-       * Babylon: TSExpressionWithTypeArguments
-       * tsep: ClassImplements
-       */
-      'class-with-implements-generic-multiple',
-      'class-with-implements-generic',
-      'class-with-implements',
-      'class-with-extends-and-implements',
-      /**
-       * Other major AST differences (e.g. fundamentally different node types)
-       */
-      'class-with-mixin',
-      'function-with-types-assignation',
-      'interface-extends-multiple',
-      'interface-extends',
-      'interface-type-parameters',
-      'interface-with-extends-type-parameters',
-      'interface-with-generic',
-      'interface-with-jsdoc',
-      'interface-with-optional-properties',
-      'interface-without-type-annotation',
-      'typed-this',
-      'export-type-function-declaration',
-      'abstract-interface',
-      'keyof-operator',
-      /**
-       * tsep bug - Program.body[0].expression.left.properties[0].value.right is currently showing up
-       * as `ArrayPattern`, babylon, acorn and espree say it should be `ArrayExpression`
-       * TODO: Fix this
-       */
-      'destructuring-assignment',
-      /**
-       * Babylon bug for optional or abstract methods?
-       */
-      'abstract-class-with-abstract-method', // babel parse errors
-      'abstract-class-with-optional-method', // babel parse errors
-      'declare-class-with-optional-method', // babel parse errors
-      /**
-       * Awaiting feedback on Babylon issue https://github.com/babel/babel/issues/6679
-       */
-      'class-with-private-parameter-properties',
-      'class-with-protected-parameter-properties',
-      'class-with-public-parameter-properties',
-      'class-with-readonly-parameter-properties',
-      /**
-       * Not yet supported in Babylon https://github.com/babel/babel/issues/7749
-       */
-      'import-type',
-      'import-type-with-type-parameters-in-type-reference'
-    ],
-    ignoreSourceType: [
-      // https://github.com/babel/babel/issues/9213
-      'export-assignment'
-    ]
-  }),
-
-  createFixturePatternConfigFor('typescript/decorators/accessor-decorators', {
-    fileType: 'ts'
-  }),
-  createFixturePatternConfigFor('typescript/decorators/class-decorators', {
-    fileType: 'ts'
-  }),
-  createFixturePatternConfigFor('typescript/decorators/method-decorators', {
-    fileType: 'ts'
-  }),
-  createFixturePatternConfigFor('typescript/decorators/parameter-decorators', {
-    fileType: 'ts'
-  }),
-  createFixturePatternConfigFor('typescript/decorators/property-decorators', {
-    fileType: 'ts'
-  }),
-
-  createFixturePatternConfigFor('typescript/expressions', {
-    fileType: 'ts',
-    ignore: [
-      /**
-       * there is difference in range between babel and tsep
-       */
-      'tagged-template-expression-type-arguments'
-    ]
-  }),
-
-  createFixturePatternConfigFor('typescript/errorRecovery', {
-    fileType: 'ts',
-    ignore: [
-      /**
-       * AST difference
-       */
-      'interface-empty-extends',
-      /**
-       * TypeScript-specific tests taken from "errorRecovery". Babylon is not being as forgiving as the TypeScript compiler here.
-       */
-      'class-empty-extends-implements', // babel parse errors
-      'class-empty-extends', // babel parse errors
-      'decorator-on-enum-declaration', // babel parse errors
-      'decorator-on-interface-declaration', // babel parse errors
-      'interface-property-modifiers', // babel parse errors
-      'enum-with-keywords' // babel parse errors
-    ]
-  }),
-
-  createFixturePatternConfigFor('typescript/declare', {
-    fileType: 'ts',
-    ignore: [
-      /**
-       * AST difference
-       * tsep: heritage = []
-       * babel: heritage = undefined
-       */
-      'interface',
-      /**
-       * AST difference
-       * tsep: TSAbstractClassDeclaration
-       * babel: ClassDeclaration[abstract=true]
-       */
-      'abstract-class'
-    ]
-  }),
-
-  createFixturePatternConfigFor('typescript/namespaces-and-modules', {
-    fileType: 'ts',
-    ignore: [
-      /**
-       * Minor AST difference
-       */
-      'nested-internal-module',
-      /**
-       * Babylon: TSDeclareFunction
-       * tsep: TSNamespaceFunctionDeclaration
-       */
-      'declare-namespace-with-exported-function'
-    ],
-    ignoreSourceType: [
-      'module-with-default-exports',
-      'ambient-module-declaration-with-import'
-    ]
-  })
-];
-
-/**
- * Add in all the fixtures which need to be parsed with sourceType: "module"
- */
-fixturePatternConfigsToTest = ([] as FixturePatternConfig[]).concat(
-  fixturePatternConfigsToTest,
-  fixturesRequiringSourceTypeModule
-);
-
-const fixturesToTest: Fixture[] = [];
-const fixturesDirPath = path.join(__dirname, '../fixtures');
-
-/**
- * Resolve the glob patterns into actual Fixture files that we can run assertions for...
- */
-fixturePatternConfigsToTest.forEach(fixturePatternConfig => {
-  /**
-   * Find the fixture files which match the given pattern
-   */
-  const matchingFixtures = glob.sync(
-    `${fixturesDirPath}/${fixturePatternConfig.pattern}`,
-    {}
-  );
-  matchingFixtures.forEach(filename => {
-    fixturesToTest.push({
-      filename,
-      ignoreSourceType: fixturePatternConfig.ignoreSourceType
-    });
-  });
+tester.addFixturePatternConfig('comments', {
+  ignore: [
+    /**
+     * Template strings seem to also be affected by the difference in opinion between different parsers in:
+     * https://github.com/babel/babel/issues/6681
+     */
+    'no-comment-template', // Purely AST diffs
+    'template-string-block' // Purely AST diffs
+  ]
 });
+
+tester.addFixturePatternConfig('javascript/templateStrings', {
+  ignore: ['**/*']
+});
+
+tester.addFixturePatternConfig('javascript/experimentalObjectRestSpread', {
+  ignore: [
+    /**
+     * Trailing comma is not permitted after a "RestElement" in Babel
+     */
+    'invalid-rest-trailing-comma'
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/arrowFunctions', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'error-dup-params', // babel parse errors
+    'error-strict-dup-params', // babel parse errors
+    'error-strict-octal', // babel parse errors
+    'error-two-lines' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/bigIntLiterals');
+tester.addFixturePatternConfig('javascript/binaryLiterals');
+tester.addFixturePatternConfig('javascript/blockBindings');
+
+tester.addFixturePatternConfig('javascript/classes', {
+  ignore: [
+    /**
+     * super() is being used outside of constructor. Other parsers (e.g. espree, acorn) do not error on this.
+     */
+    'class-one-method-super', // babel parse errors
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'invalid-class-declaration', // babel parse errors
+    'invalid-class-setter-declaration' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/defaultParams');
+
+tester.addFixturePatternConfig('javascript/destructuring', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'invalid-defaults-object-assign' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/destructuring-and-arrowFunctions');
+tester.addFixturePatternConfig('javascript/destructuring-and-blockBindings');
+tester.addFixturePatternConfig('javascript/destructuring-and-defaultParams');
+tester.addFixturePatternConfig('javascript/destructuring-and-forOf');
+
+tester.addFixturePatternConfig('javascript/destructuring-and-spread', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'error-complex-destructured-spread-first' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/experimentalAsyncIteration');
+tester.addFixturePatternConfig('javascript/experimentalDynamicImport');
+tester.addFixturePatternConfig('javascript/exponentiationOperators');
+tester.addFixturePatternConfig('javascript/experimentalOptionalCatchBinding');
+
+tester.addFixturePatternConfig('javascript/forOf', {
+  ignore: [
+    /**
+     * TypeScript, espree and acorn parse this fine - esprima, flow and babylon do not...
+     */
+    'for-of-with-function-initializer' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/generators');
+tester.addFixturePatternConfig('javascript/globalReturn');
+
+tester.addFixturePatternConfig('javascript/modules', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'invalid-export-named-default', // babel parse errors
+    'invalid-import-default-module-specifier', // babel parse errors
+    'invalid-import-module-specifier' // babel parse errors
+  ],
+  ignoreSourceType: ['error-function', 'error-strict', 'error-delete']
+});
+
+tester.addFixturePatternConfig('javascript/newTarget', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'invalid-new-target', // babel parse errors
+    'invalid-unknown-property' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/objectLiteral');
+tester.addFixturePatternConfig('javascript/objectLiteralComputedProperties');
+
+tester.addFixturePatternConfig('javascript/objectLiteralDuplicateProperties', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'error-proto-property', // babel parse errors
+    'error-proto-string-property' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/objectLiteralShorthandMethods');
+tester.addFixturePatternConfig('javascript/objectLiteralShorthandProperties');
+tester.addFixturePatternConfig('javascript/octalLiterals');
+tester.addFixturePatternConfig('javascript/regex');
+tester.addFixturePatternConfig('javascript/regexUFlag');
+tester.addFixturePatternConfig('javascript/regexYFlag');
+
+tester.addFixturePatternConfig('javascript/restParams', {
+  ignore: [
+    /**
+     * Expected babylon parse errors - all of these files below produce parse errors in espree
+     * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
+     * does not actually error on them and will produce an AST.
+     */
+    'error-no-default', // babel parse errors
+    'error-not-last' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('javascript/spread');
+tester.addFixturePatternConfig('javascript/unicodeCodePointEscapes');
+
+/* ================================================== */
+
+tester.addFixturePatternConfig('jsx', {
+  ignore: jsxFilesWithKnownIssues
+});
+tester.addFixturePatternConfig('jsx-useJSXTextNode');
+
+/* ================================================== */
+
+/**
+ * TSX-SPECIFIC FILES
+ */
+
+tester.addFixturePatternConfig('tsx', {
+  fileType: 'tsx',
+  ignore: [
+    /**
+     * currently babylon not supported
+     */
+    'generic-jsx-element'
+  ]
+});
+
+/* ================================================== */
+
+/**
+ * TYPESCRIPT-SPECIFIC FILES
+ */
+
+tester.addFixturePatternConfig('typescript/babylon-convergence', {
+  fileType: 'ts'
+});
+
+tester.addFixturePatternConfig('typescript/basics', {
+  fileType: 'ts',
+  ignore: [
+    /**
+     * Other babylon parse errors relating to invalid syntax.
+     */
+    'abstract-class-with-abstract-constructor', // babel parse errors
+    'class-with-export-parameter-properties', // babel parse errors
+    'class-with-optional-methods', // babel parse errors
+    'class-with-static-parameter-properties', // babel parse errors
+    'interface-with-all-property-types', // babel parse errors
+    'interface-with-construct-signature-with-parameter-accessibility', // babel parse errors
+    'class-with-implements-and-extends', // babel parse errors
+    /**
+     * typescript-estree erroring, but babylon not.
+     */
+    'arrow-function-with-type-parameters', // typescript-estree parse errors
+    /**
+     * Babylon: ClassDeclaration + abstract: true
+     * tsep: TSAbstractClassDeclaration
+     */
+    'abstract-class-with-abstract-properties',
+    /**
+     * Babylon: ClassProperty + abstract: true
+     * tsep: TSAbstractClassProperty
+     */
+    'abstract-class-with-abstract-readonly-property',
+    /**
+     * Babylon: TSExpressionWithTypeArguments
+     * tsep: ClassImplements
+     */
+    'class-with-implements-generic-multiple',
+    'class-with-implements-generic',
+    'class-with-implements',
+    'class-with-extends-and-implements',
+    /**
+     * Other major AST differences (e.g. fundamentally different node types)
+     */
+    'class-with-mixin',
+    'function-with-types-assignation',
+    'interface-extends-multiple',
+    'interface-extends',
+    'interface-type-parameters',
+    'interface-with-extends-type-parameters',
+    'interface-with-generic',
+    'interface-with-jsdoc',
+    'interface-with-optional-properties',
+    'interface-without-type-annotation',
+    'typed-this',
+    'export-type-function-declaration',
+    'abstract-interface',
+    'keyof-operator',
+    /**
+     * tsep bug - Program.body[0].expression.left.properties[0].value.right is currently showing up
+     * as `ArrayPattern`, babylon, acorn and espree say it should be `ArrayExpression`
+     * TODO: Fix this
+     */
+    'destructuring-assignment',
+    /**
+     * Babylon bug for optional or abstract methods?
+     */
+    'abstract-class-with-abstract-method', // babel parse errors
+    'abstract-class-with-optional-method', // babel parse errors
+    'declare-class-with-optional-method', // babel parse errors
+    /**
+     * Awaiting feedback on Babylon issue https://github.com/babel/babel/issues/6679
+     */
+    'class-with-private-parameter-properties',
+    'class-with-protected-parameter-properties',
+    'class-with-public-parameter-properties',
+    'class-with-readonly-parameter-properties',
+    /**
+     * Not yet supported in Babylon https://github.com/babel/babel/issues/7749
+     */
+    'import-type',
+    'import-type-with-type-parameters-in-type-reference'
+  ],
+  ignoreSourceType: [
+    // https://github.com/babel/babel/issues/9213
+    'export-assignment'
+  ]
+});
+
+tester.addFixturePatternConfig('typescript/decorators/accessor-decorators', {
+  fileType: 'ts'
+});
+tester.addFixturePatternConfig('typescript/decorators/class-decorators', {
+  fileType: 'ts'
+});
+tester.addFixturePatternConfig('typescript/decorators/method-decorators', {
+  fileType: 'ts'
+});
+tester.addFixturePatternConfig('typescript/decorators/parameter-decorators', {
+  fileType: 'ts'
+});
+tester.addFixturePatternConfig('typescript/decorators/property-decorators', {
+  fileType: 'ts'
+});
+
+tester.addFixturePatternConfig('typescript/expressions', {
+  fileType: 'ts',
+  ignore: [
+    /**
+     * there is difference in range between babel and tsep
+     */
+    'tagged-template-expression-type-arguments'
+  ]
+});
+
+tester.addFixturePatternConfig('typescript/errorRecovery', {
+  fileType: 'ts',
+  ignore: [
+    /**
+     * AST difference
+     */
+    'interface-empty-extends',
+    /**
+     * TypeScript-specific tests taken from "errorRecovery". Babylon is not being as forgiving as the TypeScript compiler here.
+     */
+    'class-empty-extends-implements', // babel parse errors
+    'class-empty-extends', // babel parse errors
+    'decorator-on-enum-declaration', // babel parse errors
+    'decorator-on-interface-declaration', // babel parse errors
+    'interface-property-modifiers', // babel parse errors
+    'enum-with-keywords' // babel parse errors
+  ]
+});
+
+tester.addFixturePatternConfig('typescript/declare', {
+  fileType: 'ts',
+  ignore: [
+    /**
+     * AST difference
+     * tsep: heritage = []
+     * babel: heritage = undefined
+     */
+    'interface',
+    /**
+     * AST difference
+     * tsep: TSAbstractClassDeclaration
+     * babel: ClassDeclaration[abstract=true]
+     */
+    'abstract-class'
+  ]
+});
+
+tester.addFixturePatternConfig('typescript/namespaces-and-modules', {
+  fileType: 'ts',
+  ignore: [
+    /**
+     * Minor AST difference
+     */
+    'nested-internal-module',
+    /**
+     * Babylon: TSDeclareFunction
+     * tsep: TSNamespaceFunctionDeclaration
+     */
+    'declare-namespace-with-exported-function'
+  ],
+  ignoreSourceType: [
+    'module-with-default-exports',
+    'ambient-module-declaration-with-import'
+  ]
+});
+
+const fixturesToTest = tester.getFixtures();
 
 export { fixturesToTest };

--- a/tests/ast-alignment/fixtures-to-test.ts
+++ b/tests/ast-alignment/fixtures-to-test.ts
@@ -1,29 +1,23 @@
 import glob from 'glob';
+import fs from 'fs';
 import path from 'path';
+
 import jsxKnownIssues from '../jsx-known-issues';
-import { ParserOptions as BabelParserOptions } from '@babel/parser';
-import { ParserOptions } from '../../src/temp-types-based-on-js-source';
 
 interface Fixture {
   filename: string;
-  config?: {
-    babelParserOptions?: BabelParserOptions;
-    typeScriptESTreeOptions?: ParserOptions;
-  };
+  ignoreSourceType: boolean;
 }
 
 interface FixturePatternConfig {
   pattern: string;
-  config?: {
-    babelParserOptions?: BabelParserOptions;
-    typeScriptESTreeOptions?: ParserOptions;
-  };
+  ignoreSourceType: boolean;
 }
 
 interface CreateFixturePatternConfig {
   ignore?: string[];
   fileType?: string;
-  parseWithSourceTypeModule?: string[];
+  ignoreSourceType?: string[];
 }
 
 /**
@@ -66,7 +60,7 @@ function createFixturePatternConfigFor(
   config = config || ({} as CreateFixturePatternConfig);
   config.ignore = config.ignore || [];
   config.fileType = config.fileType || 'js';
-  config.parseWithSourceTypeModule = config.parseWithSourceTypeModule || [];
+  config.ignoreSourceType = config.ignoreSourceType || [];
   /**
    * The TypeScript compiler gives us the "externalModuleIndicator" to allow typescript-estree do dynamically detect the "sourceType".
    * Babylon does not have an equivalent feature (although perhaps it might come in the future https://github.com/babel/babylon/issues/440),
@@ -77,27 +71,24 @@ function createFixturePatternConfigFor(
    * First merge the fixtures which need to be parsed with sourceType: "module" into the
    * ignore list, and then add their full config into the global array.
    */
-  if (config.parseWithSourceTypeModule.length) {
+  if (config.ignoreSourceType.length) {
     config.ignore = ([] as string[]).concat(
       config.ignore,
-      config.parseWithSourceTypeModule
+      config.ignoreSourceType
     );
-    for (const fixture of config.parseWithSourceTypeModule) {
+    for (const fixture of config.ignoreSourceType) {
       fixturesRequiringSourceTypeModule.push({
         // It needs to be the full path from within fixtures/ for the pattern
         pattern: `${fixturesSubPath}/${fixture}.src.${config.fileType}`,
-        config: {
-          babelParserOptions: {
-            sourceType: 'module'
-          }
-        }
+        ignoreSourceType: true
       });
     }
   }
   return {
     pattern: `${fixturesSubPath}/!(${config.ignore.join('|')}).src.${
       config.fileType
-    }`
+    }`,
+    ignoreSourceType: false
   };
 }
 
@@ -105,14 +96,13 @@ function createFixturePatternConfigFor(
  * An array of FixturePatternConfigs
  */
 let fixturePatternConfigsToTest = [
-  createFixturePatternConfigFor('basics'),
+  createFixturePatternConfigFor('javascript/basics'),
 
   createFixturePatternConfigFor('comments', {
     ignore: [
-      'export-default-anonymous-class', // needs to be parsed with `sourceType: "module"`
       /**
        * Template strings seem to also be affected by the difference in opinion between different parsers in:
-       * https://github.com/babel/babylon/issues/673
+       * https://github.com/babel/babel/issues/6681
        */
       'no-comment-template', // Purely AST diffs
       'template-string-block' // Purely AST diffs
@@ -126,7 +116,7 @@ let fixturePatternConfigsToTest = [
   createFixturePatternConfigFor('javascript/experimentalObjectRestSpread', {
     ignore: [
       /**
-       * Trailing comma is not permitted after a "RestElement" in Babylon
+       * Trailing comma is not permitted after a "RestElement" in Babel
        */
       'invalid-rest-trailing-comma'
     ]
@@ -139,11 +129,10 @@ let fixturePatternConfigsToTest = [
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'error-dup-params', // babylon parse errors
-      'error-dup-params', // babylon parse errors
-      'error-strict-dup-params', // babylon parse errors
-      'error-strict-octal', // babylon parse errors
-      'error-two-lines' // babylon parse errors
+      'error-dup-params', // babel parse errors
+      'error-strict-dup-params', // babel parse errors
+      'error-strict-octal', // babel parse errors
+      'error-two-lines' // babel parse errors
     ]
   }),
 
@@ -156,14 +145,14 @@ let fixturePatternConfigsToTest = [
       /**
        * super() is being used outside of constructor. Other parsers (e.g. espree, acorn) do not error on this.
        */
-      'class-one-method-super', // babylon parse errors
+      'class-one-method-super', // babel parse errors
       /**
        * Expected babylon parse errors - all of these files below produce parse errors in espree
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'invalid-class-declaration', // babylon parse errors
-      'invalid-class-setter-declaration' // babylon parse errors
+      'invalid-class-declaration', // babel parse errors
+      'invalid-class-setter-declaration' // babel parse errors
     ]
   }),
 
@@ -176,7 +165,7 @@ let fixturePatternConfigsToTest = [
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'invalid-defaults-object-assign' // babylon parse errors
+      'invalid-defaults-object-assign' // babel parse errors
     ]
   }),
 
@@ -192,20 +181,21 @@ let fixturePatternConfigsToTest = [
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'error-complex-destructured-spread-first' // babylon parse errors
+      'error-complex-destructured-spread-first' // babel parse errors
     ]
   }),
 
   createFixturePatternConfigFor('javascript/experimentalAsyncIteration'),
   createFixturePatternConfigFor('javascript/experimentalDynamicImport'),
   createFixturePatternConfigFor('javascript/exponentiationOperators'),
+  createFixturePatternConfigFor('javascript/experimentalOptionalCatchBinding'),
 
   createFixturePatternConfigFor('javascript/forOf', {
     ignore: [
       /**
        * TypeScript, espree and acorn parse this fine - esprima, flow and babylon do not...
        */
-      'for-of-with-function-initializer' // babylon parse errors
+      'for-of-with-function-initializer' // babel parse errors
     ]
   }),
 
@@ -215,72 +205,15 @@ let fixturePatternConfigsToTest = [
   createFixturePatternConfigFor('javascript/modules', {
     ignore: [
       /**
-       * TypeScript, flow and babylon parse this fine - esprima, espree and acorn do not...
-       */
-      'invalid-export-default', // typescript-estree parse errors
-      /**
        * Expected babylon parse errors - all of these files below produce parse errors in espree
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'invalid-export-named-default', // babylon parse errors
-      'invalid-import-default-module-specifier', // babylon parse errors
-      'invalid-import-module-specifier', // babylon parse errors
-      /**
-       * Deleting local variable in strict mode
-       */
-      'error-delete', // babylon parse errors
-      /**
-       * 'with' in strict mode
-       */
-      'error-strict' // babylon parse errors
+      'invalid-export-named-default', // babel parse errors
+      'invalid-import-default-module-specifier', // babel parse errors
+      'invalid-import-module-specifier' // babel parse errors
     ],
-    parseWithSourceTypeModule: [
-      'export-default-array',
-      'export-default-class',
-      'export-default-expression',
-      'export-default-function',
-      'export-default-named-class',
-      'export-default-named-function',
-      'export-default-number',
-      'export-default-object',
-      'export-default-value',
-      'export-from-batch',
-      'export-from-default',
-      'export-from-named-as-default',
-      'export-from-named-as-specifier',
-      'export-from-named-as-specifiers',
-      'export-from-specifier',
-      'export-from-specifiers',
-      'export-function',
-      'export-named-as-default',
-      'export-named-as-specifier',
-      'export-named-as-specifiers',
-      'export-named-class',
-      'export-named-empty',
-      'export-named-specifier',
-      'export-named-specifiers-comma',
-      'export-named-specifiers',
-      'export-var-anonymous-function',
-      'export-var-number',
-      'export-var',
-      'import-default-and-named-specifiers',
-      'import-default-and-namespace-specifiers',
-      'import-default-as',
-      'import-default',
-      'import-jquery',
-      'import-module',
-      'import-named-as-specifier',
-      'import-named-as-specifiers',
-      'import-named-empty',
-      'import-named-specifier',
-      'import-named-specifiers-comma',
-      'import-named-specifiers',
-      'import-namespace-specifier',
-      'import-null-as-nil',
-      'invalid-await',
-      'invalid-class'
-    ]
+    ignoreSourceType: ['error-function', 'error-strict', 'error-delete']
   }),
 
   createFixturePatternConfigFor('javascript/newTarget', {
@@ -290,11 +223,12 @@ let fixturePatternConfigsToTest = [
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'invalid-new-target', // babylon parse errors
-      'invalid-unknown-property' // babylon parse errors
+      'invalid-new-target', // babel parse errors
+      'invalid-unknown-property' // babel parse errors
     ]
   }),
 
+  createFixturePatternConfigFor('javascript/objectLiteral'),
   createFixturePatternConfigFor('javascript/objectLiteralComputedProperties'),
 
   createFixturePatternConfigFor('javascript/objectLiteralDuplicateProperties', {
@@ -304,8 +238,8 @@ let fixturePatternConfigsToTest = [
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'error-proto-property', // babylon parse errors
-      'error-proto-string-property' // babylon parse errors
+      'error-proto-property', // babel parse errors
+      'error-proto-string-property' // babel parse errors
     ]
   }),
 
@@ -323,14 +257,19 @@ let fixturePatternConfigsToTest = [
        * as well, but the TypeScript compiler is so forgiving during parsing that typescript-estree
        * does not actually error on them and will produce an AST.
        */
-      'error-no-default', // babylon parse errors
-      'error-not-last' // babylon parse errors
+      'error-no-default', // babel parse errors
+      'error-not-last' // babel parse errors
     ]
   }),
 
   createFixturePatternConfigFor('javascript/spread'),
   createFixturePatternConfigFor('javascript/unicodeCodePointEscapes'),
-  createFixturePatternConfigFor('jsx', { ignore: jsxFilesWithKnownIssues }),
+
+  /* ================================================== */
+
+  createFixturePatternConfigFor('jsx', {
+    ignore: jsxFilesWithKnownIssues
+  }),
   createFixturePatternConfigFor('jsx-useJSXTextNode'),
 
   /* ================================================== */
@@ -340,17 +279,7 @@ let fixturePatternConfigsToTest = [
    */
 
   createFixturePatternConfigFor('tsx', {
-    fileType: 'tsx',
-    ignore: [
-      /**
-       * AST difference
-       */
-      'react-typed-props',
-      /**
-       * currently babylon not supported
-       */
-      'generic-jsx-element'
-    ]
+    fileType: 'tsx'
   }),
 
   /* ================================================== */
@@ -369,13 +298,13 @@ let fixturePatternConfigsToTest = [
       /**
        * Other babylon parse errors relating to invalid syntax.
        */
-      'abstract-class-with-abstract-constructor', // babylon parse errors
-      'class-with-export-parameter-properties', // babylon parse errors
-      'class-with-optional-methods', // babylon parse errors
-      'class-with-static-parameter-properties', // babylon parse errors
-      'interface-with-all-property-types', // babylon parse errors
-      'interface-with-construct-signature-with-parameter-accessibility', // babylon parse errors
-      'class-with-implements-and-extends', // babylon parse errors
+      'abstract-class-with-abstract-constructor', // babel parse errors
+      'class-with-export-parameter-properties', // babel parse errors
+      'class-with-implements-and-extends', // babel parse errors
+      'class-with-optional-methods', // babel parse errors
+      'class-with-static-parameter-properties', // babel parse errors
+      'interface-with-all-property-types', // babel parse errors
+      'interface-with-construct-signature-with-parameter-accessibility', // babel parse errors
       /**
        * typescript-estree erroring, but babylon not.
        */
@@ -424,11 +353,11 @@ let fixturePatternConfigsToTest = [
       /**
        * Babylon bug for optional or abstract methods?
        */
-      'abstract-class-with-abstract-method', // babylon parse errors
-      'abstract-class-with-optional-method', // babylon parse errors
-      'declare-class-with-optional-method', // babylon parse errors
+      'abstract-class-with-abstract-method', // babel parse errors
+      'abstract-class-with-optional-method', // babel parse errors
+      'declare-class-with-optional-method', // babel parse errors
       /**
-       * Awaiting feedback on Babylon issue https://github.com/babel/babylon/issues/700
+       * Awaiting feedback on Babylon issue https://github.com/babel/babel/issues/6679
        */
       'class-with-private-parameter-properties',
       'class-with-protected-parameter-properties',
@@ -440,15 +369,9 @@ let fixturePatternConfigsToTest = [
       'import-type',
       'import-type-with-type-parameters-in-type-reference'
     ],
-    parseWithSourceTypeModule: [
-      'export-named-enum',
-      'export-assignment',
-      'export-type-alias-declaration',
-      'export-type-class-declaration',
-      'export-default-class-with-generic',
-      'export-default-class-with-multiple-generics',
-      'export-named-class-with-generic',
-      'export-named-class-with-multiple-generics'
+    ignoreSourceType: [
+      // https://github.com/babel/babel/issues/9213
+      'export-assignment'
     ]
   }),
 
@@ -488,12 +411,12 @@ let fixturePatternConfigsToTest = [
       /**
        * TypeScript-specific tests taken from "errorRecovery". Babylon is not being as forgiving as the TypeScript compiler here.
        */
-      'class-empty-extends-implements', // babylon parse errors
-      'class-empty-extends', // babylon parse errors
-      'decorator-on-enum-declaration', // babylon parse errors
-      'decorator-on-interface-declaration', // babylon parse errors
-      'interface-property-modifiers', // babylon parse errors
-      'enum-with-keywords' // babylon parse errors
+      'class-empty-extends-implements', // babel parse errors
+      'class-empty-extends', // babel parse errors
+      'decorator-on-enum-declaration', // babel parse errors
+      'decorator-on-interface-declaration', // babel parse errors
+      'interface-property-modifiers', // babel parse errors
+      'enum-with-keywords' // babel parse errors
     ]
   }),
 
@@ -502,14 +425,14 @@ let fixturePatternConfigsToTest = [
     ignore: [
       /**
        * AST difference
-       * tsep: TSAbstractClassDeclaration
-       * babel: ClassDeclaration[abstract=true]
+       * tsep: heritage = []
+       * babel: heritage = undefined
        */
       'interface',
       /**
        * AST difference
-       * tsep: heritage = []
-       * babel: heritage = undefined
+       * tsep: TSAbstractClassDeclaration
+       * babel: ClassDeclaration[abstract=true]
        */
       'abstract-class'
     ]
@@ -527,6 +450,10 @@ let fixturePatternConfigsToTest = [
        * tsep: TSNamespaceFunctionDeclaration
        */
       'declare-namespace-with-exported-function'
+    ],
+    ignoreSourceType: [
+      'module-with-default-exports',
+      'ambient-module-declaration-with-import'
     ]
   })
 ];
@@ -556,7 +483,7 @@ fixturePatternConfigsToTest.forEach(fixturePatternConfig => {
   matchingFixtures.forEach(filename => {
     fixturesToTest.push({
       filename,
-      config: fixturePatternConfig.config
+      ignoreSourceType: fixturePatternConfig.ignoreSourceType
     });
   });
 });

--- a/tests/ast-alignment/fixtures-to-test.ts
+++ b/tests/ast-alignment/fixtures-to-test.ts
@@ -286,13 +286,7 @@ tester.addFixturePatternConfig('jsx-useJSXTextNode');
  */
 
 tester.addFixturePatternConfig('tsx', {
-  fileType: 'tsx',
-  ignore: [
-    /**
-     * currently babylon not supported
-     */
-    'generic-jsx-element'
-  ]
+  fileType: 'tsx'
 });
 
 /* ================================================== */
@@ -313,11 +307,11 @@ tester.addFixturePatternConfig('typescript/basics', {
      */
     'abstract-class-with-abstract-constructor', // babel parse errors
     'class-with-export-parameter-properties', // babel parse errors
+    'class-with-implements-and-extends', // babel parse errors
     'class-with-optional-methods', // babel parse errors
     'class-with-static-parameter-properties', // babel parse errors
     'interface-with-all-property-types', // babel parse errors
     'interface-with-construct-signature-with-parameter-accessibility', // babel parse errors
-    'class-with-implements-and-extends', // babel parse errors
     /**
      * typescript-estree erroring, but babylon not.
      */

--- a/tests/ast-alignment/parse.ts
+++ b/tests/ast-alignment/parse.ts
@@ -19,12 +19,12 @@ function parseWithBabelParser(
   parserOptions?: BabelParserOptions
 ) {
   parserOptions = parserOptions || {};
-  const babylon = require('@babel/parser');
-  return babylon.parse(
+  const babel = require('@babel/parser');
+  return babel.parse(
     text,
     Object.assign(
       {
-        sourceType: 'script',
+        sourceType: 'unambiguous',
         allowImportExportEverywhere: true,
         allowReturnOutsideFunction: true,
         ranges: true,

--- a/tests/ast-alignment/spec.ts
+++ b/tests/ast-alignment/spec.ts
@@ -7,35 +7,29 @@ fixturesToTest.forEach(fixture => {
   const filename = fixture.filename;
   const source = fs.readFileSync(filename, 'utf8').replace(/\r\n/g, '\n');
 
-  const config = fixture.config || {};
-  config.typeScriptESTreeOptions = config.typeScriptESTreeOptions || {};
-  config.babelParserOptions = config.babelParserOptions || {};
-
   /**
    * Parse with typescript-estree
    */
   const typeScriptESTreeResult = parse(source, {
-    parser: 'typescript-estree',
-    typeScriptESTreeOptions: config.typeScriptESTreeOptions
+    parser: 'typescript-estree'
   });
 
   /**
-   * Parse the source with babylon typescript-plugin
+   * Parse the source with @babel/parser typescript-plugin
    */
   const babelParserResult = parse(source, {
-    parser: '@babel/parser',
-    babelParserOptions: config.babelParserOptions
+    parser: '@babel/parser'
   });
 
   /**
-   * If babylon fails to parse the source, ensure that typescript-estree has the same fundamental issue
+   * If babel fails to parse the source, ensure that typescript-estree has the same fundamental issue
    */
   if (babelParserResult.parseError) {
     /**
-     * FAIL: babylon errored but typescript-estree did not
+     * FAIL: babel errored but typescript-estree did not
      */
     if (!typeScriptESTreeResult.parseError) {
-      it(`TEST FAIL [BABYLON ERRORED, BUT TSEP DID NOT] - ${filename}`, () => {
+      it(`TEST FAIL [BABEL ERRORED, BUT TSEP DID NOT] - ${filename}`, () => {
         expect(typeScriptESTreeResult.parseError).toEqual(
           babelParserResult.parseError
         );
@@ -54,10 +48,10 @@ fixturesToTest.forEach(fixture => {
   }
 
   /**
-   * FAIL: typescript-estree errored but babylon did not
+   * FAIL: typescript-estree errored but babel did not
    */
   if (typeScriptESTreeResult.parseError) {
-    it(`TEST FAIL [TSEP ERRORED, BUT BABYLON DID NOT] - ${filename}`, () => {
+    it(`TEST FAIL [TSEP ERRORED, BUT BABEL DID NOT] - ${filename}`, () => {
       expect(babelParserResult.parseError).toEqual(
         typeScriptESTreeResult.parseError
       );
@@ -72,14 +66,18 @@ fixturesToTest.forEach(fixture => {
     expect(babelParserResult.ast).toBeTruthy();
     expect(typeScriptESTreeResult.ast).toBeTruthy();
     /**
-     * Perform some extra formatting steps on the babylon AST before comparing
+     * Perform some extra formatting steps on the babel AST before comparing
      */
     expect(
-      parseUtils.removeLocationDataFromProgramNode(
-        parseUtils.preprocessBabylonAST(babelParserResult.ast)
+      parseUtils.removeLocationDataAndSourceTypeFromProgramNode(
+        parseUtils.preprocessBabylonAST(babelParserResult.ast),
+        fixture.ignoreSourceType
       )
     ).toEqual(
-      parseUtils.removeLocationDataFromProgramNode(typeScriptESTreeResult.ast)
+      parseUtils.removeLocationDataAndSourceTypeFromProgramNode(
+        typeScriptESTreeResult.ast,
+        fixture.ignoreSourceType
+      )
     );
   });
 });

--- a/tests/ast-alignment/utils.ts
+++ b/tests/ast-alignment/utils.ts
@@ -142,10 +142,17 @@ export function preprocessBabylonAST(ast: any): any {
  * See: https://github.com/babel/babylon/issues/673
  *
  * @param {Object} ast the raw AST with a Program node at its top level
+ * @param {boolean} ignoreSourceType fix for issues with unambiguous type detection
  * @returns {Object} the ast with the location data removed from the Program node
  */
-export function removeLocationDataFromProgramNode(ast: any) {
+export function removeLocationDataAndSourceTypeFromProgramNode(
+  ast: any,
+  ignoreSourceType: boolean
+) {
   delete ast.loc;
   delete ast.range;
+  if (ignoreSourceType) {
+    delete ast.sourceType;
+  }
   return ast;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,7 +213,12 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.1.6", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
+"@babel/parser@7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.3.tgz#32f5df65744b70888d17872ec106b02434ba1489"
+  integrity sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==
+
+"@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.6.tgz#16e97aca1ec1062324a01c5a6a7d0df8dd189854"
   integrity sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==
@@ -2281,7 +2286,7 @@ debug@^4.0.0, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3472,7 +3477,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4679,11 +4684,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4692,32 +4692,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -4798,11 +4776,6 @@ lodash.pick@4.4.0, lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -6518,7 +6491,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
This PR changes babel sourceType to unambiguous, additionally i found out that javascript/basic tests are not executed

`FixturesTester` is doing what this messy code in `fixures-to-test.ts` was doing with additional check if files test directory is present, this make code easier to read and understund

## sourceType [`unambiguous`](https://github.com/babel/babel/pull/6789):

Babel added autodetection of sourceType, with that i was able to remove most of `parseWithSourceTypeModule` and leave it in only 4 files
i renamed this property to `ignoreSourceType` and changed logic to ignore source type comparison instead of not doing comparison at all.

there is one more issue with autodetection in babel: https://github.com/babel/babel/issues/9213

@JamesHenry what do you think about this?
those changes got extracted from #52 