### PR TITLE
fix: add missing TSInferType node

### DIFF
--- a/src/ast-node-types.ts
+++ b/src/ast-node-types.ts
@@ -115,6 +115,7 @@ export const AST_NODE_TYPES: { [key: string]: string } = {
   TSExportAssignment: 'TSExportAssignment',
   TSExportKeyword: 'TSExportKeyword',
   TSImportType: 'TSImportType',
+  TSInferType: 'TSInferType',
   TSLiteralType: 'TSLiteralType',
   TSIndexedAccessType: 'TSIndexedAccessType',
   TSIndexSignature: 'TSIndexSignature',

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -2690,7 +2690,13 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
       });
       break;
     }
-
+    case SyntaxKind.InferType: {
+      Object.assign(result, {
+        type: AST_NODE_TYPES.TSInferType,
+        typeParameter: convertChildType(node.typeParameter)
+      });
+      break;
+    }
     default:
       deeplyCopy();
   }

--- a/tests/fixtures/typescript/types/conditional-infer-nested.src.ts
+++ b/tests/fixtures/typescript/types/conditional-infer-nested.src.ts
@@ -1,0 +1,5 @@
+type Unpacked<T> =
+  T extends (infer U)[] ? U :
+    T extends infer U ? U :
+      T extends Promise<infer U> ? U :
+        T;

--- a/tests/fixtures/typescript/types/conditional-infer-simple.src.ts
+++ b/tests/fixtures/typescript/types/conditional-infer-simple.src.ts
@@ -1,0 +1,1 @@
+type Foo<T> = T extends { a: infer U, b: infer U } ? U : never;

--- a/tests/fixtures/typescript/types/conditional-infer.src.ts
+++ b/tests/fixtures/typescript/types/conditional-infer.src.ts
@@ -1,0 +1,1 @@
+type Element<T> = T extends (infer U)[] ? U : T;

--- a/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -1884,6 +1884,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" en
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional-with-null.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/indexed.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -1886,6 +1886,10 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" en
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer-nested.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer-simple.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/conditional-with-null.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/types/indexed.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/tests/lib/__snapshots__/typescript.ts.snap
+++ b/tests/lib/__snapshots__/typescript.ts.snap
@@ -78188,6 +78188,636 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/types/conditional-infer.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        "name": "Element",
+        "range": Array [
+          5,
+          12,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        48,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "checkType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 18,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            18,
+            19,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 19,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 18,
+                "line": 1,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              18,
+              19,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "extendsType": Object {
+          "elementType": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 37,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 28,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              28,
+              37,
+            ],
+            "type": "TSParenthesizedType",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 36,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 29,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                29,
+                36,
+              ],
+              "type": "TSInferType",
+              "typeParameter": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 36,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 35,
+                    "line": 1,
+                  },
+                },
+                "name": "U",
+                "range": Array [
+                  35,
+                  36,
+                ],
+                "type": "TSTypeParameter",
+              },
+            },
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 39,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 28,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            28,
+            39,
+          ],
+          "type": "TSArrayType",
+        },
+        "falseType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 47,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 46,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            46,
+            47,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 47,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 46,
+                "line": 1,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              46,
+              47,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 47,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 18,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          18,
+          47,
+        ],
+        "trueType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 43,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 42,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            42,
+            43,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 43,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 42,
+                "line": 1,
+              },
+            },
+            "name": "U",
+            "range": Array [
+              42,
+              43,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "type": "TSConditionalType",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 15,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 12,
+            "line": 1,
+          },
+        },
+        "params": Array [
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 13,
+                "line": 1,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              13,
+              14,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          12,
+          15,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    49,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        12,
+      ],
+      "type": "Identifier",
+      "value": "Element",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        13,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        14,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        18,
+        19,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        20,
+        27,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        28,
+        29,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        29,
+        34,
+      ],
+      "type": "Identifier",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        36,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        36,
+        37,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 38,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        37,
+        38,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 39,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        40,
+        41,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 43,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        42,
+        43,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        44,
+        45,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 47,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        46,
+        47,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        47,
+        48,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/types/conditional-with-null.src 1`] = `
 Object {
   "body": Array [

--- a/tests/lib/__snapshots__/typescript.ts.snap
+++ b/tests/lib/__snapshots__/typescript.ts.snap
@@ -78818,6 +78818,2068 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/types/conditional-infer-nested.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 13,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        "name": "Unpacked",
+        "range": Array [
+          5,
+          13,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        126,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "checkType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 3,
+              "line": 2,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 2,
+            },
+          },
+          "range": Array [
+            21,
+            22,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 3,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              21,
+              22,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "extendsType": Object {
+          "elementType": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 21,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 12,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              31,
+              40,
+            ],
+            "type": "TSParenthesizedType",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 20,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 2,
+                },
+              },
+              "range": Array [
+                32,
+                39,
+              ],
+              "type": "TSInferType",
+              "typeParameter": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 20,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 19,
+                    "line": 2,
+                  },
+                },
+                "name": "U",
+                "range": Array [
+                  38,
+                  39,
+                ],
+                "type": "TSTypeParameter",
+              },
+            },
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 2,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 2,
+            },
+          },
+          "range": Array [
+            31,
+            42,
+          ],
+          "type": "TSArrayType",
+        },
+        "falseType": Object {
+          "checkType": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              53,
+              54,
+            ],
+            "type": "TSTypeReference",
+            "typeName": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 3,
+                },
+              },
+              "name": "T",
+              "range": Array [
+                53,
+                54,
+              ],
+              "type": "Identifier",
+            },
+          },
+          "extendsType": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 21,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              63,
+              70,
+            ],
+            "type": "TSInferType",
+            "typeParameter": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 20,
+                  "line": 3,
+                },
+              },
+              "name": "U",
+              "range": Array [
+                69,
+                70,
+              ],
+              "type": "TSTypeParameter",
+            },
+          },
+          "falseType": Object {
+            "checkType": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 7,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 6,
+                  "line": 4,
+                },
+              },
+              "range": Array [
+                83,
+                84,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 7,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 6,
+                    "line": 4,
+                  },
+                },
+                "name": "T",
+                "range": Array [
+                  83,
+                  84,
+                ],
+                "type": "Identifier",
+              },
+            },
+            "extendsType": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 32,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 16,
+                  "line": 4,
+                },
+              },
+              "range": Array [
+                93,
+                109,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 16,
+                    "line": 4,
+                  },
+                },
+                "name": "Promise",
+                "range": Array [
+                  93,
+                  100,
+                ],
+                "type": "Identifier",
+              },
+              "typeParameters": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 32,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 23,
+                    "line": 4,
+                  },
+                },
+                "params": Array [
+                  Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 31,
+                        "line": 4,
+                      },
+                      "start": Object {
+                        "column": 24,
+                        "line": 4,
+                      },
+                    },
+                    "range": Array [
+                      101,
+                      108,
+                    ],
+                    "type": "TSInferType",
+                    "typeParameter": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 31,
+                          "line": 4,
+                        },
+                        "start": Object {
+                          "column": 30,
+                          "line": 4,
+                        },
+                      },
+                      "name": "U",
+                      "range": Array [
+                        107,
+                        108,
+                      ],
+                      "type": "TSTypeParameter",
+                    },
+                  },
+                ],
+                "range": Array [
+                  100,
+                  109,
+                ],
+                "type": "TSTypeParameterInstantiation",
+              },
+            },
+            "falseType": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 9,
+                  "line": 5,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 5,
+                },
+              },
+              "range": Array [
+                124,
+                125,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 5,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 5,
+                  },
+                },
+                "name": "T",
+                "range": Array [
+                  124,
+                  125,
+                ],
+                "type": "Identifier",
+              },
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 5,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 4,
+              },
+            },
+            "range": Array [
+              83,
+              125,
+            ],
+            "trueType": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 36,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 35,
+                  "line": 4,
+                },
+              },
+              "range": Array [
+                112,
+                113,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 36,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 35,
+                    "line": 4,
+                  },
+                },
+                "name": "U",
+                "range": Array [
+                  112,
+                  113,
+                ],
+                "type": "Identifier",
+              },
+            },
+            "type": "TSConditionalType",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 5,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 3,
+            },
+          },
+          "range": Array [
+            53,
+            125,
+          ],
+          "trueType": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 25,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 24,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              73,
+              74,
+            ],
+            "type": "TSTypeReference",
+            "typeName": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 25,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 24,
+                  "line": 3,
+                },
+              },
+              "name": "U",
+              "range": Array [
+                73,
+                74,
+              ],
+              "type": "Identifier",
+            },
+          },
+          "type": "TSConditionalType",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 9,
+            "line": 5,
+          },
+          "start": Object {
+            "column": 2,
+            "line": 2,
+          },
+        },
+        "range": Array [
+          21,
+          125,
+        ],
+        "trueType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 27,
+              "line": 2,
+            },
+            "start": Object {
+              "column": 26,
+              "line": 2,
+            },
+          },
+          "range": Array [
+            45,
+            46,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 27,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 26,
+                "line": 2,
+              },
+            },
+            "name": "U",
+            "range": Array [
+              45,
+              46,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "type": "TSConditionalType",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 16,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 13,
+            "line": 1,
+          },
+        },
+        "params": Array [
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 1,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              14,
+              15,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          13,
+          16,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 6,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    127,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        13,
+      ],
+      "type": "Identifier",
+      "value": "Unpacked",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        14,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        15,
+        16,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        17,
+        18,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        22,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        23,
+        30,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        31,
+        32,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        32,
+        37,
+      ],
+      "type": "Identifier",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        39,
+        40,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        40,
+        41,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        41,
+        42,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        43,
+        44,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        45,
+        46,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        47,
+        48,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        53,
+        54,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        55,
+        62,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        63,
+        68,
+      ],
+      "type": "Identifier",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        69,
+        70,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        71,
+        72,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        73,
+        74,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        75,
+        76,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        83,
+        84,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        85,
+        92,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        93,
+        100,
+      ],
+      "type": "Identifier",
+      "value": "Promise",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        100,
+        101,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        101,
+        106,
+      ],
+      "type": "Identifier",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 30,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        107,
+        108,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 32,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        108,
+        109,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        110,
+        111,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        112,
+        113,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 38,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 37,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        114,
+        115,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        124,
+        125,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        125,
+        126,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`typescript fixtures/types/conditional-infer-simple.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 8,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        "name": "Foo",
+        "range": Array [
+          5,
+          8,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 63,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        63,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "checkType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            14,
+            15,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 1,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              14,
+              15,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "extendsType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 50,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 24,
+              "line": 1,
+            },
+          },
+          "members": Array [
+            Object {
+              "computed": false,
+              "key": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 27,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 26,
+                    "line": 1,
+                  },
+                },
+                "name": "a",
+                "range": Array [
+                  26,
+                  27,
+                ],
+                "type": "Identifier",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 37,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 26,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                26,
+                37,
+              ],
+              "type": "TSPropertySignature",
+              "typeAnnotation": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 36,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 27,
+                    "line": 1,
+                  },
+                },
+                "range": Array [
+                  27,
+                  36,
+                ],
+                "type": "TSTypeAnnotation",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 36,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 29,
+                      "line": 1,
+                    },
+                  },
+                  "range": Array [
+                    29,
+                    36,
+                  ],
+                  "type": "TSInferType",
+                  "typeParameter": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 36,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 35,
+                        "line": 1,
+                      },
+                    },
+                    "name": "U",
+                    "range": Array [
+                      35,
+                      36,
+                    ],
+                    "type": "TSTypeParameter",
+                  },
+                },
+              },
+            },
+            Object {
+              "computed": false,
+              "key": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 39,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 38,
+                    "line": 1,
+                  },
+                },
+                "name": "b",
+                "range": Array [
+                  38,
+                  39,
+                ],
+                "type": "Identifier",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 48,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 38,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                38,
+                48,
+              ],
+              "type": "TSPropertySignature",
+              "typeAnnotation": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 48,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 39,
+                    "line": 1,
+                  },
+                },
+                "range": Array [
+                  39,
+                  48,
+                ],
+                "type": "TSTypeAnnotation",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 48,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 41,
+                      "line": 1,
+                    },
+                  },
+                  "range": Array [
+                    41,
+                    48,
+                  ],
+                  "type": "TSInferType",
+                  "typeParameter": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 48,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 47,
+                        "line": 1,
+                      },
+                    },
+                    "name": "U",
+                    "range": Array [
+                      47,
+                      48,
+                    ],
+                    "type": "TSTypeParameter",
+                  },
+                },
+              },
+            },
+          ],
+          "range": Array [
+            24,
+            50,
+          ],
+          "type": "TSTypeLiteral",
+        },
+        "falseType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 62,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 57,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            57,
+            62,
+          ],
+          "type": "TSNeverKeyword",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 62,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 14,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          14,
+          62,
+        ],
+        "trueType": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 54,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 53,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            53,
+            54,
+          ],
+          "type": "TSTypeReference",
+          "typeName": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 54,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 53,
+                "line": 1,
+              },
+            },
+            "name": "U",
+            "range": Array [
+              53,
+              54,
+            ],
+            "type": "Identifier",
+          },
+        },
+        "type": "TSConditionalType",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 11,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 8,
+            "line": 1,
+          },
+        },
+        "params": Array [
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 9,
+                "line": 1,
+              },
+            },
+            "name": "T",
+            "range": Array [
+              9,
+              10,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          8,
+          11,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    64,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        8,
+      ],
+      "type": "Identifier",
+      "value": "Foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        8,
+        9,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        10,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        10,
+        11,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        13,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "T",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        23,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        24,
+        25,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        26,
+        27,
+      ],
+      "type": "Identifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        27,
+        28,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        29,
+        34,
+      ],
+      "type": "Identifier",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        36,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        36,
+        37,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 39,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Identifier",
+      "value": "b",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 40,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        39,
+        40,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 46,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        41,
+        46,
+      ],
+      "type": "Identifier",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        47,
+        48,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 50,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        49,
+        50,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 52,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        51,
+        52,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 54,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        53,
+        54,
+      ],
+      "type": "Identifier",
+      "value": "U",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 56,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        55,
+        56,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 62,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        57,
+        62,
+      ],
+      "type": "Identifier",
+      "value": "never",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 63,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        62,
+        63,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/types/conditional-with-null.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
This PR is not changing AST

- [x] Add missing node type `TSInferType`
- [x] Add test cases

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#type-inference-in-conditional-types