### PR TITLE
feat: add missing TSNamespaceExportDeclaration node

### DIFF
--- a/src/ast-node-types.ts
+++ b/src/ast-node-types.ts
@@ -131,6 +131,7 @@ export const AST_NODE_TYPES: { [key: string]: string } = {
   TSModuleBlock: 'TSModuleBlock',
   TSModuleDeclaration: 'TSModuleDeclaration',
   TSNamespaceFunctionDeclaration: 'TSNamespaceFunctionDeclaration',
+  TSNamespaceExportDeclaration: 'TSNamespaceExportDeclaration',
   TSNonNullExpression: 'TSNonNullExpression',
   TSNeverKeyword: 'TSNeverKeyword',
   TSNullKeyword: 'TSNullKeyword',

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -2711,6 +2711,13 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
       });
       break;
     }
+    case SyntaxKind.NamespaceExportDeclaration: {
+      Object.assign(result, {
+        type: AST_NODE_TYPES.TSNamespaceExportDeclaration,
+        id: convertChild(node.name)
+      });
+      break;
+    }
 
     default:
       deeplyCopy();

--- a/tests/fixtures/typescript/basics/export-as-namespace.src.ts
+++ b/tests/fixtures/typescript/basics/export-as-namespace.src.ts
@@ -1,0 +1,1 @@
+export as namespace a;

--- a/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -1760,6 +1760,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" en
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/basics/directive-in-namespace.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/basics/export-as-namespace.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/basics/export-assignment.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntaticAndSemanticIssues" enabled fixtures/typescript/basics/export-default-class-with-generic.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/tests/lib/__snapshots__/typescript.ts.snap
+++ b/tests/lib/__snapshots__/typescript.ts.snap
@@ -28708,6 +28708,156 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/export-as-namespace.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 21,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 20,
+            "line": 1,
+          },
+        },
+        "name": "a",
+        "range": Array [
+          20,
+          21,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        22,
+      ],
+      "type": "TSNamespaceExportDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    23,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        6,
+      ],
+      "type": "Keyword",
+      "value": "export",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        9,
+      ],
+      "type": "Identifier",
+      "value": "as",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        10,
+        19,
+      ],
+      "type": "Identifier",
+      "value": "namespace",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        20,
+        21,
+      ],
+      "type": "Identifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        21,
+        22,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/export-assignment.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
This feature was added in typescript 2.2.0 and can be used only in declarations.

read more: https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#support-for-umd-module-definitions

looks like its last missing node from https://github.com/armano2/typescript-estree-test/blob/master/report.json