### PR TITLE
feat: update TSIndexSignature node and enable error TS1071

### DIFF
--- a/src/ast-node-types.ts
+++ b/src/ast-node-types.ts
@@ -39,7 +39,6 @@ export enum AST_NODE_TYPES {
   ForStatement = 'ForStatement',
   FunctionDeclaration = 'FunctionDeclaration',
   FunctionExpression = 'FunctionExpression',
-  GenericTypeAnnotation = 'GenericTypeAnnotation',
   Identifier = 'Identifier',
   IfStatement = 'IfStatement',
   Import = 'Import',
@@ -56,7 +55,7 @@ export enum AST_NODE_TYPES {
   JSXFragment = 'JSXFragment',
   JSXIdentifier = 'JSXIdentifier',
   JSXMemberExpression = 'JSXMemberExpression',
-  JSXNamespacedName = 'JSXNamespacedName',
+  JSXNamespacedName = 'JSXNamespacedName', // https://github.com/Microsoft/TypeScript/issues/7411
   JSXOpeningElement = 'JSXOpeningElement',
   JSXOpeningFragment = 'JSXOpeningFragment',
   JSXSpreadAttribute = 'JSXSpreadAttribute',

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -2418,20 +2418,26 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
     case SyntaxKind.IndexSignature: {
       Object.assign(result, {
         type: AST_NODE_TYPES.TSIndexSignature,
-        index: convertChild(node.parameters[0]),
-        typeAnnotation: node.type ? convertTypeAnnotation(node.type) : null,
-        readonly:
-          nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node) || undefined,
-        static: nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node),
-        export:
-          nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node) || undefined
+        parameters: node.parameters.map(convertChild),
+        typeAnnotation: node.type ? convertTypeAnnotation(node.type) : null
       });
+
+      if (nodeUtils.hasModifier(SyntaxKind.ReadonlyKeyword, node)) {
+        result.readonly = true;
+      }
 
       const accessibility = nodeUtils.getTSNodeAccessibility(node);
       if (accessibility) {
         result.accessibility = accessibility;
       }
 
+      if (nodeUtils.hasModifier(SyntaxKind.ExportKeyword, node)) {
+        result.export = true;
+      }
+
+      if (nodeUtils.hasModifier(SyntaxKind.StaticKeyword, node)) {
+        result.static = true;
+      }
       break;
     }
     case SyntaxKind.ConstructorType:

--- a/src/semantic-errors.ts
+++ b/src/semantic-errors.ts
@@ -60,6 +60,7 @@ function whitelistSupportedDiagnostics(
       case 1048: // ts 3.2 "A rest parameter cannot have an initializer."
       case 1049: // ts 3.2 "A 'set' accessor must have exactly one parameter."
       case 1070: // ts 3.2 "'{0}' modifier cannot appear on a type member."
+      case 1071: // ts 3.2 "'{0}' modifier cannot appear on an index signature."
       case 1090: // ts 3.2 "'{0}' modifier cannot appear on a parameter."
       case 1096: // ts 3.2 "An index signature must have exactly one parameter."
       case 1097: // ts 3.2 "'{0}' list cannot be empty."

--- a/tests/ast-alignment/fixtures-to-test.ts
+++ b/tests/ast-alignment/fixtures-to-test.ts
@@ -488,6 +488,7 @@ tester.addFixturePatternConfig('typescript/types', {
      */
     'index-signature',
     'index-signature-readonly',
+    'index-signature-without-type',
     'literal-number-negative'
   ]
 });

--- a/tests/ast-alignment/fixtures-to-test.ts
+++ b/tests/ast-alignment/fixtures-to-test.ts
@@ -468,15 +468,7 @@ tester.addFixturePatternConfig('typescript/errorRecovery', {
      * TODO: remove me in next babel > 7.2.3
      */
     'interface-empty-extends',
-    'class-extends-empty-implements',
-    /**
-     * TS1071
-     */
-    'interface-index-signature-export',
-    'interface-index-signature-private',
-    'interface-index-signature-protected',
-    'interface-index-signature-public',
-    'interface-index-signature-static'
+    'class-extends-empty-implements'
   ]
 });
 
@@ -484,11 +476,15 @@ tester.addFixturePatternConfig('typescript/types', {
   fileType: 'ts',
   ignore: [
     /**
-     * AST difference
+     * Babel bug for range of Identifier in TSIndexSignature
+     * https://github.com/babel/babel/issues/9319
      */
     'index-signature',
     'index-signature-readonly',
     'index-signature-without-type',
+    /**
+     * AST difference
+     */
     'literal-number-negative'
   ]
 });

--- a/tests/fixtures/typescript/types/index-signature-without-type.src.ts
+++ b/tests/fixtures/typescript/types/index-signature-without-type.src.ts
@@ -1,0 +1,3 @@
+type foo = {
+  [a: string];
+}

--- a/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -2212,15 +2212,50 @@ Object {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-export.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-export.src.ts.src 1`] = `
+Object {
+  "column": 2,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'export' modifier cannot appear on an index signature.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-private.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-private.src.ts.src 1`] = `
+Object {
+  "column": 2,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'private' modifier cannot appear on an index signature.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-protected.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-protected.src.ts.src 1`] = `
+Object {
+  "column": 2,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'protected' modifier cannot appear on an index signature.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-public.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-public.src.ts.src 1`] = `
+Object {
+  "column": 2,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'public' modifier cannot appear on an index signature.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-static.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-static.src.ts.src 1`] = `
+Object {
+  "column": 2,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'static' modifier cannot appear on an index signature.",
+}
+`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-export.src.ts.src 1`] = `
 Object {

--- a/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -2382,6 +2382,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/index-signature-readonly.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/index-signature-without-type.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/indexed.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/intersection-type.src.ts.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/tests/lib/__snapshots__/typescript.ts.snap
+++ b/tests/lib/__snapshots__/typescript.ts.snap
@@ -99373,6 +99373,354 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/types/index-signature-without-type.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 8,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        "name": "foo",
+        "range": Array [
+          5,
+          8,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        29,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 11,
+            "line": 1,
+          },
+        },
+        "members": Array [
+          Object {
+            "index": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 12,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 2,
+                },
+              },
+              "name": "a",
+              "range": Array [
+                16,
+                25,
+              ],
+              "type": "Identifier",
+              "typeAnnotation": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 12,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 4,
+                    "line": 2,
+                  },
+                },
+                "range": Array [
+                  17,
+                  25,
+                ],
+                "type": "TSTypeAnnotation",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 12,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 6,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    19,
+                    25,
+                  ],
+                  "type": "TSStringKeyword",
+                },
+              },
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              15,
+              27,
+            ],
+            "static": false,
+            "type": "TSIndexSignature",
+            "typeAnnotation": null,
+          },
+        ],
+        "range": Array [
+          11,
+          29,
+        ],
+        "type": "TSTypeLiteral",
+      },
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 4,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    30,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        8,
+      ],
+      "type": "Identifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        10,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        11,
+        12,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        15,
+        16,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Identifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        17,
+        18,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        19,
+        25,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        25,
+        26,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        26,
+        27,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        28,
+        29,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/types/indexed.src 1`] = `
 Object {
   "body": Array [

--- a/tests/lib/__snapshots__/typescript.ts.snap
+++ b/tests/lib/__snapshots__/typescript.ts.snap
@@ -41474,58 +41474,6 @@ Object {
             },
           },
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 16,
-                  "line": 6,
-                },
-                "start": Object {
-                  "column": 5,
-                  "line": 6,
-                },
-              },
-              "name": "eee",
-              "range": Array [
-                95,
-                106,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 16,
-                    "line": 6,
-                  },
-                  "start": Object {
-                    "column": 8,
-                    "line": 6,
-                  },
-                },
-                "range": Array [
-                  98,
-                  106,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 16,
-                      "line": 6,
-                    },
-                    "start": Object {
-                      "column": 10,
-                      "line": 6,
-                    },
-                  },
-                  "range": Array [
-                    100,
-                    106,
-                  ],
-                  "type": "TSNumberKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 26,
@@ -41536,11 +41484,64 @@ Object {
                 "line": 6,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "column": 5,
+                    "line": 6,
+                  },
+                },
+                "name": "eee",
+                "range": Array [
+                  95,
+                  106,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 16,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 8,
+                      "line": 6,
+                    },
+                  },
+                  "range": Array [
+                    98,
+                    106,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 16,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 10,
+                        "line": 6,
+                      },
+                    },
+                    "range": Array [
+                      100,
+                      106,
+                    ],
+                    "type": "TSNumberKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               94,
               116,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -41578,59 +41579,6 @@ Object {
             },
           },
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 17,
-                  "line": 7,
-                },
-                "start": Object {
-                  "column": 5,
-                  "line": 7,
-                },
-              },
-              "name": "fff",
-              "optional": true,
-              "range": Array [
-                122,
-                134,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 17,
-                    "line": 7,
-                  },
-                  "start": Object {
-                    "column": 9,
-                    "line": 7,
-                  },
-                },
-                "range": Array [
-                  126,
-                  134,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 17,
-                      "line": 7,
-                    },
-                    "start": Object {
-                      "column": 11,
-                      "line": 7,
-                    },
-                  },
-                  "range": Array [
-                    128,
-                    134,
-                  ],
-                  "type": "TSNumberKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 27,
@@ -41641,11 +41589,65 @@ Object {
                 "line": 7,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 5,
+                    "line": 7,
+                  },
+                },
+                "name": "fff",
+                "optional": true,
+                "range": Array [
+                  122,
+                  134,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 7,
+                    },
+                    "start": Object {
+                      "column": 9,
+                      "line": 7,
+                    },
+                  },
+                  "range": Array [
+                    126,
+                    134,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 17,
+                        "line": 7,
+                      },
+                      "start": Object {
+                        "column": 11,
+                        "line": 7,
+                      },
+                    },
+                    "range": Array [
+                      128,
+                      134,
+                    ],
+                    "type": "TSNumberKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               121,
               144,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -78401,58 +78403,6 @@ Object {
         },
         "members": Array [
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 12,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 3,
-                  "line": 2,
-                },
-              },
-              "name": "a",
-              "range": Array [
-                16,
-                25,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 12,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 4,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  17,
-                  25,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 12,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 6,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    19,
-                    25,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 33,
@@ -78463,11 +78413,116 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 12,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "name": "a",
+                "range": Array [
+                  16,
+                  25,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 12,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 4,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    17,
+                    25,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 12,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      19,
+                      25,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 14,
+                    "line": 2,
+                  },
+                },
+                "name": "b",
+                "range": Array [
+                  27,
+                  36,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 15,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    28,
+                    36,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 23,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 17,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      30,
+                      36,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               15,
               46,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -79017,58 +79072,6 @@ Object {
         "body": Array [
           Object {
             "export": true,
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 21,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 10,
-                  "line": 2,
-                },
-              },
-              "name": "baz",
-              "range": Array [
-                26,
-                37,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 21,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 13,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  29,
-                  37,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 21,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 15,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    31,
-                    37,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 31,
@@ -79079,11 +79082,64 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 10,
+                    "line": 2,
+                  },
+                },
+                "name": "baz",
+                "range": Array [
+                  26,
+                  37,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 13,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    29,
+                    37,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 21,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 15,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      31,
+                      37,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               18,
               47,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -79436,58 +79492,6 @@ Object {
         "body": Array [
           Object {
             "accessibility": "private",
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 22,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 11,
-                  "line": 2,
-                },
-              },
-              "name": "baz",
-              "range": Array [
-                27,
-                38,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 22,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 14,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  30,
-                  38,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 22,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 16,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    32,
-                    38,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 32,
@@ -79498,11 +79502,64 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 22,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 11,
+                    "line": 2,
+                  },
+                },
+                "name": "baz",
+                "range": Array [
+                  27,
+                  38,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 22,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 14,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    30,
+                    38,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 22,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 16,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      32,
+                      38,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               18,
               48,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -79855,58 +79912,6 @@ Object {
         "body": Array [
           Object {
             "accessibility": "protected",
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 24,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 13,
-                  "line": 2,
-                },
-              },
-              "name": "baz",
-              "range": Array [
-                29,
-                40,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 24,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 16,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  32,
-                  40,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 24,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 18,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    34,
-                    40,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 34,
@@ -79917,11 +79922,64 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 24,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 2,
+                  },
+                },
+                "name": "baz",
+                "range": Array [
+                  29,
+                  40,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 24,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 16,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    32,
+                    40,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 24,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 18,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      34,
+                      40,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               18,
               50,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -80274,58 +80332,6 @@ Object {
         "body": Array [
           Object {
             "accessibility": "public",
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 21,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 10,
-                  "line": 2,
-                },
-              },
-              "name": "baz",
-              "range": Array [
-                26,
-                37,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 21,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 13,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  29,
-                  37,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 21,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 15,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    31,
-                    37,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 31,
@@ -80336,11 +80342,64 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 10,
+                    "line": 2,
+                  },
+                },
+                "name": "baz",
+                "range": Array [
+                  26,
+                  37,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 13,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    29,
+                    37,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 21,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 15,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      31,
+                      37,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               18,
               47,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -80692,58 +80751,6 @@ Object {
       "body": Object {
         "body": Array [
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 21,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 10,
-                  "line": 2,
-                },
-              },
-              "name": "baz",
-              "range": Array [
-                26,
-                37,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 21,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 13,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  29,
-                  37,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 21,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 15,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    31,
-                    37,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 31,
@@ -80754,6 +80761,60 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 10,
+                    "line": 2,
+                  },
+                },
+                "name": "baz",
+                "range": Array [
+                  26,
+                  37,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 13,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    29,
+                    37,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 21,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 15,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      31,
+                      37,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               18,
               47,
@@ -98570,58 +98631,6 @@ Object {
         },
         "members": Array [
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 12,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 3,
-                  "line": 2,
-                },
-              },
-              "name": "a",
-              "range": Array [
-                16,
-                25,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 12,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 4,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  17,
-                  25,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 12,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 6,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    19,
-                    25,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 22,
@@ -98632,11 +98641,64 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 12,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "name": "a",
+                "range": Array [
+                  16,
+                  25,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 12,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 4,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    17,
+                    25,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 12,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      19,
+                      25,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               15,
               35,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -98987,58 +99049,6 @@ Object {
         },
         "members": Array [
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 23,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 12,
-                  "line": 2,
-                },
-              },
-              "name": "key",
-              "range": Array [
-                25,
-                36,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 23,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 15,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  28,
-                  36,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 23,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 17,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    30,
-                    36,
-                  ],
-                  "type": "TSNumberKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 33,
@@ -99049,12 +99059,65 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 12,
+                    "line": 2,
+                  },
+                },
+                "name": "key",
+                "range": Array [
+                  25,
+                  36,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 15,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    28,
+                    36,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 23,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 17,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      30,
+                      36,
+                    ],
+                    "type": "TSNumberKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               15,
               46,
             ],
             "readonly": true,
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": Object {
               "loc": Object {
@@ -99423,58 +99486,6 @@ Object {
         },
         "members": Array [
           Object {
-            "index": Object {
-              "loc": Object {
-                "end": Object {
-                  "column": 12,
-                  "line": 2,
-                },
-                "start": Object {
-                  "column": 3,
-                  "line": 2,
-                },
-              },
-              "name": "a",
-              "range": Array [
-                16,
-                25,
-              ],
-              "type": "Identifier",
-              "typeAnnotation": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 12,
-                    "line": 2,
-                  },
-                  "start": Object {
-                    "column": 4,
-                    "line": 2,
-                  },
-                },
-                "range": Array [
-                  17,
-                  25,
-                ],
-                "type": "TSTypeAnnotation",
-                "typeAnnotation": Object {
-                  "loc": Object {
-                    "end": Object {
-                      "column": 12,
-                      "line": 2,
-                    },
-                    "start": Object {
-                      "column": 6,
-                      "line": 2,
-                    },
-                  },
-                  "range": Array [
-                    19,
-                    25,
-                  ],
-                  "type": "TSStringKeyword",
-                },
-              },
-            },
             "loc": Object {
               "end": Object {
                 "column": 14,
@@ -99485,11 +99496,64 @@ Object {
                 "line": 2,
               },
             },
+            "parameters": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 12,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "name": "a",
+                "range": Array [
+                  16,
+                  25,
+                ],
+                "type": "Identifier",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 12,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 4,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    17,
+                    25,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 12,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 2,
+                      },
+                    },
+                    "range": Array [
+                      19,
+                      25,
+                    ],
+                    "type": "TSStringKeyword",
+                  },
+                },
+              },
+            ],
             "range": Array [
               15,
               27,
             ],
-            "static": false,
             "type": "TSIndexSignature",
             "typeAnnotation": null,
           },


### PR DESCRIPTION
This PR align structure of node `TSIndexSignature` with babel

i was not able to enable alignment tests due to https://github.com/babel/babel/issues/9319

#112