### PR TITLE
test: improve workflow for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - commitlint-travis
   - yarn check-format
-  - yarn test
+  - yarn test --ci
   - yarn build
   - yarn global add codecov
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - commitlint-travis
   - yarn check-format
-  - yarn test --ci
+  - yarn test
   - yarn build
   - yarn global add codecov
 after_success:

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest'
   },
   testRegex: './tests/(lib/.*\\.(jsx?|tsx?)|ast-alignment/spec\\.ts)$',
-  collectCoverage: true,
+  collectCoverage: false,
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   coverageReporters: ['text-summary', 'lcov']

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --coverage",
     "unit-tests": "jest \"./tests/lib/.*\"",
     "ast-alignment-tests": "jest spec.ts",
     "precommit": "npm test && lint-staged",


### PR DESCRIPTION
This PR changes test workflow for development
- `collectCoverage` option is broken with node-inspector / debugging
- partial tests should not report coverage