### PR TITLE
refactor: add explicit implementation of TSLiteralType

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -2686,6 +2686,13 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
       });
       break;
     }
+    case SyntaxKind.LiteralType: {
+      Object.assign(result, {
+        type: AST_NODE_TYPES.TSLiteralType,
+        literal: convertChildType(node.literal)
+      });
+      break;
+    }
     case SyntaxKind.TypeAssertionExpression: {
       Object.assign(result, {
         type: AST_NODE_TYPES.TSTypeAssertion,


### PR DESCRIPTION
i expect that coverage will go down after this one, `deeplyCopy` is not triggered for nodes.